### PR TITLE
Put back phase_shift field in ctf metadata

### DIFF
--- a/schema/linkml/image_entities.yaml
+++ b/schema/linkml/image_entities.yaml
@@ -36,6 +36,10 @@ slots:
   defocus_angle:
     description: Estimated angle of astigmatism.
     range: float
+  phase_shift:
+    description: Phase shift value produced by the usage of a phase plate.
+    range: float
+
   particle_index:
     description: Index of a particle inside a tomogram.
     range: integer
@@ -63,6 +67,7 @@ classes:
       - defocus_u
       - defocus_v
       - defocus_angle
+      - phase_shift
       - defocus_handedness
     slot_usage:
       defocus_handedness:

--- a/src/cets_data_model/models/models.py
+++ b/src/cets_data_model/models/models.py
@@ -499,6 +499,10 @@ class CTFMetadata(ConfiguredBaseModel):
     defocus_angle: Optional[float] = Field(
         default=None, description="""Estimated angle of astigmatism."""
     )
+    phase_shift: Optional[float] = Field(
+        default=None,
+        description="""Phase shift value produced by the usage of a phase plate.""",
+    )
     defocus_handedness: Optional[int] = Field(
         default=-1,
         description="""The handedness of the tilt geometry used to describe whether the focus increases or decreases as a function of Z distance.""",


### PR DESCRIPTION
As discussed previously, the `phase_shift` field is now specified in the linkml yaml, and present in the generated models. 