### PR TITLE
Add id fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -207,3 +207,8 @@ marimo/_lsp/
 __marimo__/
 
 .idea/
+.DS_Store
+schema/.DS_Store
+src/.DS_Store
+src/cets_data_model/.DS_Store
+tests/.DS_Store

--- a/schema/linkml/alignment.yaml
+++ b/schema/linkml/alignment.yaml
@@ -18,6 +18,8 @@ classes:
   ProjectionAlignment:
     is_a: CoordinateTransformation
     description: The tomographic alignment for a single projection.
+    slots:
+      - target_id
     slot_usage:
       transformation_type:
         ifabsent: TransformationType(projection_alignment)

--- a/schema/linkml/annotation.yaml
+++ b/schema/linkml/annotation.yaml
@@ -153,8 +153,6 @@ classes:
     slots:
       - annotation_type
       - name
-      - target_id
-      - id
   SegmentationMask2D:
     is_a: Annotation
     mixins:
@@ -173,6 +171,9 @@ classes:
     slot_usage:
       annotation_type:
         ifabsent: AnnotationType(segmentation_mask_3D)
+      id:
+        required: false
+        ifabsent: string()
   ProbabilityMap2D:
     is_a: Annotation
     mixins:
@@ -182,6 +183,9 @@ classes:
     slot_usage:
       annotation_type:
         ifabsent: AnnotationType(probability_map_2D)
+      id:
+        required: false
+        ifabsent: string()
   ProbabilityMap3D:
     is_a: Annotation
     mixins:
@@ -191,6 +195,9 @@ classes:
     slot_usage:
       annotation_type:
         ifabsent: AnnotationType(probability_map_3D)
+      id:
+        required: false
+        ifabsent: string()
   PointSet2D:
     is_a: Annotation
     mixins:

--- a/schema/linkml/annotation.yaml
+++ b/schema/linkml/annotation.yaml
@@ -133,7 +133,9 @@ slots:
             minimum_cardinality: 1
           - alias: xyz
             minimum_cardinality: 3
-
+  - target_id:
+      description: The entity the annotation applies to
+      range: string
 classes:
   CoordMetaMixin:
     description: Coordinate system mixins for annotations.
@@ -151,6 +153,8 @@ classes:
     slots:
       - annotation_type
       - name
+      - target_id
+      - id
   SegmentationMask2D:
     is_a: Annotation
     mixins:

--- a/schema/linkml/annotation.yaml
+++ b/schema/linkml/annotation.yaml
@@ -172,8 +172,7 @@ classes:
       annotation_type:
         ifabsent: AnnotationType(segmentation_mask_3D)
       id:
-        required: false
-        ifabsent: string()
+        required: true
   ProbabilityMap2D:
     is_a: Annotation
     mixins:
@@ -184,8 +183,7 @@ classes:
       annotation_type:
         ifabsent: AnnotationType(probability_map_2D)
       id:
-        required: false
-        ifabsent: string()
+        required: true
   ProbabilityMap3D:
     is_a: Annotation
     mixins:
@@ -196,8 +194,7 @@ classes:
       annotation_type:
         ifabsent: AnnotationType(probability_map_3D)
       id:
-        required: false
-        ifabsent: string()
+        required: true
   PointSet2D:
     is_a: Annotation
     mixins:

--- a/schema/linkml/common.yaml
+++ b/schema/linkml/common.yaml
@@ -16,6 +16,7 @@ slots:
   name:
     description: A human-readable name or title for this entity
     range: string
+    ifabsent: ""
   id:
     description: Unique identifier for this entity
     range: string
@@ -23,3 +24,5 @@ slots:
   path:
     description: Path to a file.
     range: string
+    ifabsent: ""
+

--- a/schema/linkml/coordinate_transforms.yaml
+++ b/schema/linkml/coordinate_transforms.yaml
@@ -18,10 +18,7 @@ slots:
     description: The type of transformation.
     range: TransformationType
     required: true
-  target_id:
-    description: The entity this transformation creates
-    range: string
-    required: false
+
 
 classes:
   CoordinateTransformation:
@@ -106,7 +103,7 @@ classes:
     description: A sequence of transformations
     is_a: CoordinateTransformation
     slots:
-      - target_id
+      - transformation_type
     slot_usage:
       transformation_type:
         ifabsent: TransformationType(sequence)
@@ -115,6 +112,11 @@ classes:
         description: The sequence of transformations
         range: CoordinateTransformation
         multivalued: true
+      target_id:
+        description: The entity this transformation creates
+        range: string
+        required: false
+
 
 enums:
   TransformationType:

--- a/schema/linkml/coordinate_transforms.yaml
+++ b/schema/linkml/coordinate_transforms.yaml
@@ -18,6 +18,10 @@ slots:
     description: The type of transformation.
     range: TransformationType
     required: true
+  target_id:
+    description: The entity this transformation creates
+    range: string
+    required: false
 
 classes:
   CoordinateTransformation:
@@ -101,6 +105,8 @@ classes:
   Sequence:
     description: A sequence of transformations
     is_a: CoordinateTransformation
+    slots:
+      - target_id
     slot_usage:
       transformation_type:
         ifabsent: TransformationType(sequence)

--- a/schema/linkml/entities.yaml
+++ b/schema/linkml/entities.yaml
@@ -23,10 +23,12 @@ classes:
       a specimen.
     slots:
       - id
+      - name
     attributes:
       movie_stack_collection:
         description: The movie stack
         range: MovieStackCollection
+        inlined: true
       tilt_series:
         description: The tilt series
         range: TiltSeries
@@ -36,6 +38,7 @@ classes:
         description: The alignments
         range: Alignment
         multivalued: true
+        inlined_as_list: true
       tomograms:
         description: The tomograms
         range: Tomogram
@@ -45,23 +48,29 @@ classes:
         description: The annotations for this region
         range: Annotation
         multivalued: true
+        inlined_as_list: true
 
   Average:
     description: A particle averaging experiment.
     slots:
+      - id
       - name
     attributes:
       particle_maps:
         description: The particle maps
         range: ParticleMap
         multivalued: true
+        inlined_as_list: true
       annotations:
         description: The annotations
         range: Annotation
         multivalued: true
+        inlined_as_list: true
 
   MovieStackCollection:
     description: A collection of movie stacks using the same gain and defect files.
+    slots:
+      - name
     attributes:
       movie_stacks:
         description: The movie stacks in the collection
@@ -71,14 +80,17 @@ classes:
       gain_file:
         description: The gain file for the movie stacks
         range: GainFile
+        inlined: true
       defect_file:
         description: The defect file for the movie stacks
         range: DefectFile
+        inlined: true
 
   Dataset:
     description: A dataset
     slots:
       - name
+      - id
     attributes:
       regions:
         description: The regions in the dataset
@@ -89,3 +101,4 @@ classes:
         description: The averages in the dataset
         range: Average
         multivalued: true
+        inlined_as_list: true

--- a/schema/linkml/image.yaml
+++ b/schema/linkml/image.yaml
@@ -61,6 +61,7 @@ classes:
         description: The images in the stack
         range: Image2D
         multivalued: true
+        inlined_as_list: true
       id:
         description: The id of the stack
         range: string
@@ -78,6 +79,7 @@ classes:
         description: The images in the stack
         range: Image3D
         multivalued: true
+        inlined_as_list: true
       id:
         description: The id of the stack
         range: string

--- a/schema/linkml/image.yaml
+++ b/schema/linkml/image.yaml
@@ -11,6 +11,7 @@ default_prefix: image
 imports:
 - linkml:types
 - ./coordinate_systems
+- ./common
 
 slots:
   width:
@@ -39,6 +40,8 @@ classes:
       - height
       - coordinate_systems
       - coordinate_transformations
+      - id
+      - path
 
   Image3D:
     description: A 3D image.
@@ -48,6 +51,8 @@ classes:
       - depth
       - coordinate_systems
       - coordinate_transformations
+      - id
+      - path
 
   ImageStack2D:
     description: A stack of 2D images.
@@ -56,6 +61,15 @@ classes:
         description: The images in the stack
         range: Image2D
         multivalued: true
+      id:
+        description: The id of the stack
+        range: string
+      name:
+        description: Name for the stack
+        range: string
+      path:
+        description: Path to the stack file
+        range: string
 
   ImageStack3D:
     description: A stack of 3D images.
@@ -64,4 +78,13 @@ classes:
         description: The images in the stack
         range: Image3D
         multivalued: true
+      id:
+        description: The id of the stack
+        range: string
+      name:
+        description: Name for the stack
+        range: string
+      path:
+        description: Path to the stack file
+        range: string
 

--- a/schema/linkml/image_entities.yaml
+++ b/schema/linkml/image_entities.yaml
@@ -178,8 +178,7 @@ classes:
       - path
     slot_usage:
       id:
-        required: false
-        ifabsent: string()
+        required: true
 
 
 

--- a/schema/linkml/image_entities.yaml
+++ b/schema/linkml/image_entities.yaml
@@ -39,7 +39,6 @@ slots:
   phase_shift:
     description: Phase shift value produced by the usage of a phase plate.
     range: float
-
   particle_index:
     description: Index of a particle inside a tomogram.
     range: integer
@@ -106,10 +105,12 @@ classes:
         description: The movie frames in the stack
         range: MovieFrame
         multivalued: true
+        inlined_as_list: true
   MovieStackSeries:
     description: A group of movie stacks that belong to a single tilt series.
     slots:
       - id
+      - name
     attributes:
       stacks:
         description: The movie stacks.
@@ -175,6 +176,10 @@ classes:
     description: A 3D particle density map.
     slots:
       - path
+    slot_usage:
+      id:
+        required: false
+        ifabsent: string()
 
 
 

--- a/src/cets_data_model/models/models.py
+++ b/src/cets_data_model/models/models.py
@@ -246,7 +246,7 @@ class ImageStack2D(ConfiguredBaseModel):
     A stack of 2D images.
     """
 
-    images: Optional[list[str]] = Field(
+    images: Optional[list[Image2D]] = Field(
         default=[], description="""The images in the stack"""
     )
     id: Optional[str] = Field(default=None, description="""The id of the stack""")
@@ -259,7 +259,7 @@ class ImageStack3D(ConfiguredBaseModel):
     A stack of 3D images.
     """
 
-    images: Optional[list[str]] = Field(
+    images: Optional[list[Image3D]] = Field(
         default=[], description="""The images in the stack"""
     )
     id: Optional[str] = Field(default=None, description="""The id of the stack""")
@@ -438,8 +438,8 @@ class Sequence(CoordinateTransformation):
     A sequence of transformations
     """
 
-    target_id: Optional[str] = Field(
-        default=None, description="""The entity the annotation applies to"""
+    transformation_type: Literal[TransformationType.sequence] = Field(
+        TransformationType.sequence, description="""The type of transformation."""
     )
     sequence: Optional[
         list[
@@ -449,8 +449,8 @@ class Sequence(CoordinateTransformation):
             ]
         ]
     ] = Field(default=[], description="""The sequence of transformations""")
-    transformation_type: Literal[TransformationType.sequence] = Field(
-        TransformationType.sequence, description="""The type of transformation."""
+    target_id: Optional[str] = Field(
+        default=None, description="""The entity this transformation creates"""
     )
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
@@ -932,7 +932,7 @@ class ParticleMap(Image3D):
     ] = Field(
         default=[], description="""Named coordinate transformations for this entity"""
     )
-    id: str = Field(default="", description="""Unique identifier for this entity""")
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
 
 
 class CoordMetaMixin(ConfiguredBaseModel):
@@ -1037,7 +1037,7 @@ class SegmentationMask3D(Annotation, AssociatedFile, Image3D):
     ] = Field(
         default=[], description="""Named coordinate transformations for this entity"""
     )
-    id: str = Field(default="", description="""Unique identifier for this entity""")
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
     path: Optional[str] = Field(default=None, description="""Path to a file.""")
     annotation_type: Literal[AnnotationType.segmentation_mask_3D] = Field(
         AnnotationType.segmentation_mask_3D, description="""The type of annotation."""
@@ -1071,7 +1071,7 @@ class ProbabilityMap2D(Annotation, AssociatedFile, Image2D):
     ] = Field(
         default=[], description="""Named coordinate transformations for this entity"""
     )
-    id: str = Field(default="", description="""Unique identifier for this entity""")
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
     path: Optional[str] = Field(default=None, description="""Path to a file.""")
     annotation_type: Literal[AnnotationType.probability_map_2D] = Field(
         AnnotationType.probability_map_2D, description="""The type of annotation."""
@@ -1108,7 +1108,7 @@ class ProbabilityMap3D(Annotation, AssociatedFile, Image3D):
     ] = Field(
         default=[], description="""Named coordinate transformations for this entity"""
     )
-    id: str = Field(default="", description="""Unique identifier for this entity""")
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
     path: Optional[str] = Field(default=None, description="""Path to a file.""")
     annotation_type: Literal[AnnotationType.probability_map_3D] = Field(
         AnnotationType.probability_map_3D, description="""The type of annotation."""

--- a/src/cets_data_model/models/models.py
+++ b/src/cets_data_model/models/models.py
@@ -974,10 +974,6 @@ class Annotation(ConfiguredBaseModel):
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
     )
-    target_id: Optional[str] = Field(
-        default=None, description="""The entity the annotation applies to"""
-    )
-    id: str = Field(default=..., description="""Unique identifier for this entity""")
 
 
 class SegmentationMask2D(Annotation, AssociatedFile, Image2D):
@@ -1012,9 +1008,6 @@ class SegmentationMask2D(Annotation, AssociatedFile, Image2D):
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
     )
-    target_id: Optional[str] = Field(
-        default=None, description="""The entity the annotation applies to"""
-    )
 
 
 class SegmentationMask3D(Annotation, AssociatedFile, Image3D):
@@ -1044,16 +1037,13 @@ class SegmentationMask3D(Annotation, AssociatedFile, Image3D):
     ] = Field(
         default=[], description="""Named coordinate transformations for this entity"""
     )
-    id: str = Field(default=..., description="""Unique identifier for this entity""")
+    id: str = Field(default="", description="""Unique identifier for this entity""")
     path: Optional[str] = Field(default=None, description="""Path to a file.""")
     annotation_type: Literal[AnnotationType.segmentation_mask_3D] = Field(
         AnnotationType.segmentation_mask_3D, description="""The type of annotation."""
     )
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
-    )
-    target_id: Optional[str] = Field(
-        default=None, description="""The entity the annotation applies to"""
     )
 
 
@@ -1081,16 +1071,13 @@ class ProbabilityMap2D(Annotation, AssociatedFile, Image2D):
     ] = Field(
         default=[], description="""Named coordinate transformations for this entity"""
     )
-    id: str = Field(default=..., description="""Unique identifier for this entity""")
+    id: str = Field(default="", description="""Unique identifier for this entity""")
     path: Optional[str] = Field(default=None, description="""Path to a file.""")
     annotation_type: Literal[AnnotationType.probability_map_2D] = Field(
         AnnotationType.probability_map_2D, description="""The type of annotation."""
     )
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
-    )
-    target_id: Optional[str] = Field(
-        default=None, description="""The entity the annotation applies to"""
     )
 
 
@@ -1121,16 +1108,13 @@ class ProbabilityMap3D(Annotation, AssociatedFile, Image3D):
     ] = Field(
         default=[], description="""Named coordinate transformations for this entity"""
     )
-    id: str = Field(default=..., description="""Unique identifier for this entity""")
+    id: str = Field(default="", description="""Unique identifier for this entity""")
     path: Optional[str] = Field(default=None, description="""Path to a file.""")
     annotation_type: Literal[AnnotationType.probability_map_3D] = Field(
         AnnotationType.probability_map_3D, description="""The type of annotation."""
     )
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
-    )
-    target_id: Optional[str] = Field(
-        default=None, description="""The entity the annotation applies to"""
     )
 
 
@@ -1161,10 +1145,6 @@ class PointSet2D(Annotation, CoordMetaMixin):
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
     )
-    target_id: Optional[str] = Field(
-        default=None, description="""The entity the annotation applies to"""
-    )
-    id: str = Field(default=..., description="""Unique identifier for this entity""")
 
 
 class PointSet3D(Annotation, CoordMetaMixin):
@@ -1194,10 +1174,6 @@ class PointSet3D(Annotation, CoordMetaMixin):
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
     )
-    target_id: Optional[str] = Field(
-        default=None, description="""The entity the annotation applies to"""
-    )
-    id: str = Field(default=..., description="""Unique identifier for this entity""")
 
 
 class PointVectorSet2D(Annotation, CoordMetaMixin):
@@ -1231,10 +1207,6 @@ class PointVectorSet2D(Annotation, CoordMetaMixin):
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
     )
-    target_id: Optional[str] = Field(
-        default=None, description="""The entity the annotation applies to"""
-    )
-    id: str = Field(default=..., description="""Unique identifier for this entity""")
 
 
 class PointVectorSet3D(Annotation, CoordMetaMixin):
@@ -1268,10 +1240,6 @@ class PointVectorSet3D(Annotation, CoordMetaMixin):
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
     )
-    target_id: Optional[str] = Field(
-        default=None, description="""The entity the annotation applies to"""
-    )
-    id: str = Field(default=..., description="""Unique identifier for this entity""")
 
 
 class PointMatrixSet2D(Annotation, CoordMetaMixin):
@@ -1305,10 +1273,6 @@ class PointMatrixSet2D(Annotation, CoordMetaMixin):
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
     )
-    target_id: Optional[str] = Field(
-        default=None, description="""The entity the annotation applies to"""
-    )
-    id: str = Field(default=..., description="""Unique identifier for this entity""")
 
 
 class PointMatrixSet3D(Annotation, CoordMetaMixin):
@@ -1342,10 +1306,6 @@ class PointMatrixSet3D(Annotation, CoordMetaMixin):
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
     )
-    target_id: Optional[str] = Field(
-        default=None, description="""The entity the annotation applies to"""
-    )
-    id: str = Field(default=..., description="""Unique identifier for this entity""")
 
 
 class TriMesh(Annotation, CoordMetaMixin):
@@ -1372,10 +1332,6 @@ class TriMesh(Annotation, CoordMetaMixin):
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
     )
-    target_id: Optional[str] = Field(
-        default=None, description="""The entity the annotation applies to"""
-    )
-    id: str = Field(default=..., description="""Unique identifier for this entity""")
 
 
 class SphereSet(Annotation, CoordMetaMixin):
@@ -1408,10 +1364,6 @@ class SphereSet(Annotation, CoordMetaMixin):
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
     )
-    target_id: Optional[str] = Field(
-        default=None, description="""The entity the annotation applies to"""
-    )
-    id: str = Field(default=..., description="""Unique identifier for this entity""")
 
 
 class CircleSet(Annotation, CoordMetaMixin):
@@ -1444,10 +1396,6 @@ class CircleSet(Annotation, CoordMetaMixin):
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
     )
-    target_id: Optional[str] = Field(
-        default=None, description="""The entity the annotation applies to"""
-    )
-    id: str = Field(default=..., description="""Unique identifier for this entity""")
 
 
 class CylinderSet(Annotation, CoordMetaMixin):
@@ -1481,10 +1429,6 @@ class CylinderSet(Annotation, CoordMetaMixin):
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
     )
-    target_id: Optional[str] = Field(
-        default=None, description="""The entity the annotation applies to"""
-    )
-    id: str = Field(default=..., description="""Unique identifier for this entity""")
 
 
 class CuboidSet(Annotation, CoordMetaMixin):
@@ -1521,10 +1465,6 @@ class CuboidSet(Annotation, CoordMetaMixin):
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
     )
-    target_id: Optional[str] = Field(
-        default=None, description="""The entity the annotation applies to"""
-    )
-    id: str = Field(default=..., description="""Unique identifier for this entity""")
 
 
 class BoxSet(Annotation, CoordMetaMixin):
@@ -1561,10 +1501,6 @@ class BoxSet(Annotation, CoordMetaMixin):
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
     )
-    target_id: Optional[str] = Field(
-        default=None, description="""The entity the annotation applies to"""
-    )
-    id: str = Field(default=..., description="""Unique identifier for this entity""")
 
 
 class Spline2D(Annotation, CoordMetaMixin):
@@ -1594,10 +1530,6 @@ class Spline2D(Annotation, CoordMetaMixin):
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
     )
-    target_id: Optional[str] = Field(
-        default=None, description="""The entity the annotation applies to"""
-    )
-    id: str = Field(default=..., description="""Unique identifier for this entity""")
 
 
 class Spline3D(Annotation, CoordMetaMixin):
@@ -1627,10 +1559,6 @@ class Spline3D(Annotation, CoordMetaMixin):
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
     )
-    target_id: Optional[str] = Field(
-        default=None, description="""The entity the annotation applies to"""
-    )
-    id: str = Field(default=..., description="""Unique identifier for this entity""")
 
 
 class DensityMap(Annotation, AssociatedFile, Image3D):
@@ -1671,9 +1599,6 @@ class DensityMap(Annotation, AssociatedFile, Image3D):
     )
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
-    )
-    target_id: Optional[str] = Field(
-        default=None, description="""The entity the annotation applies to"""
     )
 
 

--- a/src/cets_data_model/models/models.py
+++ b/src/cets_data_model/models/models.py
@@ -206,6 +206,8 @@ class Image2D(ConfiguredBaseModel):
     ] = Field(
         default=[], description="""Named coordinate transformations for this entity"""
     )
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
+    path: Optional[str] = Field(default=None, description="""Path to a file.""")
 
 
 class Image3D(ConfiguredBaseModel):
@@ -235,6 +237,8 @@ class Image3D(ConfiguredBaseModel):
     ] = Field(
         default=[], description="""Named coordinate transformations for this entity"""
     )
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
+    path: Optional[str] = Field(default=None, description="""Path to a file.""")
 
 
 class ImageStack2D(ConfiguredBaseModel):
@@ -242,9 +246,12 @@ class ImageStack2D(ConfiguredBaseModel):
     A stack of 2D images.
     """
 
-    images: Optional[list[Image2D]] = Field(
+    images: Optional[list[str]] = Field(
         default=[], description="""The images in the stack"""
     )
+    id: Optional[str] = Field(default=None, description="""The id of the stack""")
+    name: Optional[str] = Field(default=None, description="""Name for the stack""")
+    path: Optional[str] = Field(default=None, description="""Path to the stack file""")
 
 
 class ImageStack3D(ConfiguredBaseModel):
@@ -252,9 +259,12 @@ class ImageStack3D(ConfiguredBaseModel):
     A stack of 3D images.
     """
 
-    images: Optional[list[Image3D]] = Field(
+    images: Optional[list[str]] = Field(
         default=[], description="""The images in the stack"""
     )
+    id: Optional[str] = Field(default=None, description="""The id of the stack""")
+    name: Optional[str] = Field(default=None, description="""Name for the stack""")
+    path: Optional[str] = Field(default=None, description="""Path to the stack file""")
 
 
 class Axis(ConfiguredBaseModel):
@@ -428,6 +438,9 @@ class Sequence(CoordinateTransformation):
     A sequence of transformations
     """
 
+    target_id: Optional[str] = Field(
+        default=None, description="""The entity the annotation applies to"""
+    )
     sequence: Optional[
         list[
             Annotated[
@@ -455,6 +468,9 @@ class ProjectionAlignment(CoordinateTransformation):
     The tomographic alignment for a single projection.
     """
 
+    target_id: Optional[str] = Field(
+        default=None, description="""The entity the annotation applies to"""
+    )
     sequence: Optional[list[Union[Affine, Translation]]] = Field(
         default=[], description="""The sequence of transformations""", max_length=2
     )
@@ -550,6 +566,7 @@ class GainFile(Image2D):
     ] = Field(
         default=[], description="""Named coordinate transformations for this entity"""
     )
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
 
 
 class DefectFile(Image2D):
@@ -577,6 +594,7 @@ class DefectFile(Image2D):
     ] = Field(
         default=[], description="""Named coordinate transformations for this entity"""
     )
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
 
 
 class MovieFrame(AcquisitionMetadataMixin, Image2D):
@@ -617,6 +635,7 @@ class MovieFrame(AcquisitionMetadataMixin, Image2D):
     ] = Field(
         default=[], description="""Named coordinate transformations for this entity"""
     )
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
 
 
 class MovieStack(ConfiguredBaseModel):
@@ -637,6 +656,9 @@ class MovieStackSeries(ConfiguredBaseModel):
     """
 
     id: str = Field(default=..., description="""Unique identifier for this entity""")
+    name: Optional[str] = Field(
+        default=None, description="""A human-readable name or title for this entity"""
+    )
     stacks: Optional[list[MovieStack]] = Field(
         default=[], description="""The movie stacks."""
     )
@@ -680,6 +702,7 @@ class BaseProjectionImage(AcquisitionMetadataMixin, Image2D):
     ] = Field(
         default=[], description="""Named coordinate transformations for this entity"""
     )
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
 
 
 class ProjectionImage(BaseProjectionImage):
@@ -720,6 +743,7 @@ class ProjectionImage(BaseProjectionImage):
     ] = Field(
         default=[], description="""Named coordinate transformations for this entity"""
     )
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
 
 
 class SubProjectionImage(ProjectionImage):
@@ -763,6 +787,7 @@ class SubProjectionImage(ProjectionImage):
     ] = Field(
         default=[], description="""Named coordinate transformations for this entity"""
     )
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
 
 
 class TiltImage(BaseProjectionImage):
@@ -806,6 +831,7 @@ class TiltImage(BaseProjectionImage):
     ] = Field(
         default=[], description="""Named coordinate transformations for this entity"""
     )
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
 
 
 class TiltSeries(ConfiguredBaseModel):
@@ -906,6 +932,7 @@ class ParticleMap(Image3D):
     ] = Field(
         default=[], description="""Named coordinate transformations for this entity"""
     )
+    id: str = Field(default="", description="""Unique identifier for this entity""")
 
 
 class CoordMetaMixin(ConfiguredBaseModel):
@@ -947,6 +974,10 @@ class Annotation(ConfiguredBaseModel):
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
     )
+    target_id: Optional[str] = Field(
+        default=None, description="""The entity the annotation applies to"""
+    )
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
 
 
 class SegmentationMask2D(Annotation, AssociatedFile, Image2D):
@@ -973,12 +1004,16 @@ class SegmentationMask2D(Annotation, AssociatedFile, Image2D):
     ] = Field(
         default=[], description="""Named coordinate transformations for this entity"""
     )
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
     path: Optional[str] = Field(default=None, description="""Path to a file.""")
     annotation_type: Literal[AnnotationType.segmentation_mask_2D] = Field(
         AnnotationType.segmentation_mask_2D, description="""The type of annotation."""
     )
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
+    )
+    target_id: Optional[str] = Field(
+        default=None, description="""The entity the annotation applies to"""
     )
 
 
@@ -1009,12 +1044,16 @@ class SegmentationMask3D(Annotation, AssociatedFile, Image3D):
     ] = Field(
         default=[], description="""Named coordinate transformations for this entity"""
     )
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
     path: Optional[str] = Field(default=None, description="""Path to a file.""")
     annotation_type: Literal[AnnotationType.segmentation_mask_3D] = Field(
         AnnotationType.segmentation_mask_3D, description="""The type of annotation."""
     )
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
+    )
+    target_id: Optional[str] = Field(
+        default=None, description="""The entity the annotation applies to"""
     )
 
 
@@ -1042,12 +1081,16 @@ class ProbabilityMap2D(Annotation, AssociatedFile, Image2D):
     ] = Field(
         default=[], description="""Named coordinate transformations for this entity"""
     )
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
     path: Optional[str] = Field(default=None, description="""Path to a file.""")
     annotation_type: Literal[AnnotationType.probability_map_2D] = Field(
         AnnotationType.probability_map_2D, description="""The type of annotation."""
     )
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
+    )
+    target_id: Optional[str] = Field(
+        default=None, description="""The entity the annotation applies to"""
     )
 
 
@@ -1078,12 +1121,16 @@ class ProbabilityMap3D(Annotation, AssociatedFile, Image3D):
     ] = Field(
         default=[], description="""Named coordinate transformations for this entity"""
     )
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
     path: Optional[str] = Field(default=None, description="""Path to a file.""")
     annotation_type: Literal[AnnotationType.probability_map_3D] = Field(
         AnnotationType.probability_map_3D, description="""The type of annotation."""
     )
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
+    )
+    target_id: Optional[str] = Field(
+        default=None, description="""The entity the annotation applies to"""
     )
 
 
@@ -1114,6 +1161,10 @@ class PointSet2D(Annotation, CoordMetaMixin):
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
     )
+    target_id: Optional[str] = Field(
+        default=None, description="""The entity the annotation applies to"""
+    )
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
 
 
 class PointSet3D(Annotation, CoordMetaMixin):
@@ -1143,6 +1194,10 @@ class PointSet3D(Annotation, CoordMetaMixin):
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
     )
+    target_id: Optional[str] = Field(
+        default=None, description="""The entity the annotation applies to"""
+    )
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
 
 
 class PointVectorSet2D(Annotation, CoordMetaMixin):
@@ -1176,6 +1231,10 @@ class PointVectorSet2D(Annotation, CoordMetaMixin):
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
     )
+    target_id: Optional[str] = Field(
+        default=None, description="""The entity the annotation applies to"""
+    )
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
 
 
 class PointVectorSet3D(Annotation, CoordMetaMixin):
@@ -1209,6 +1268,10 @@ class PointVectorSet3D(Annotation, CoordMetaMixin):
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
     )
+    target_id: Optional[str] = Field(
+        default=None, description="""The entity the annotation applies to"""
+    )
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
 
 
 class PointMatrixSet2D(Annotation, CoordMetaMixin):
@@ -1242,6 +1305,10 @@ class PointMatrixSet2D(Annotation, CoordMetaMixin):
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
     )
+    target_id: Optional[str] = Field(
+        default=None, description="""The entity the annotation applies to"""
+    )
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
 
 
 class PointMatrixSet3D(Annotation, CoordMetaMixin):
@@ -1275,6 +1342,10 @@ class PointMatrixSet3D(Annotation, CoordMetaMixin):
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
     )
+    target_id: Optional[str] = Field(
+        default=None, description="""The entity the annotation applies to"""
+    )
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
 
 
 class TriMesh(Annotation, CoordMetaMixin):
@@ -1301,6 +1372,10 @@ class TriMesh(Annotation, CoordMetaMixin):
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
     )
+    target_id: Optional[str] = Field(
+        default=None, description="""The entity the annotation applies to"""
+    )
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
 
 
 class SphereSet(Annotation, CoordMetaMixin):
@@ -1333,6 +1408,10 @@ class SphereSet(Annotation, CoordMetaMixin):
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
     )
+    target_id: Optional[str] = Field(
+        default=None, description="""The entity the annotation applies to"""
+    )
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
 
 
 class CircleSet(Annotation, CoordMetaMixin):
@@ -1365,6 +1444,10 @@ class CircleSet(Annotation, CoordMetaMixin):
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
     )
+    target_id: Optional[str] = Field(
+        default=None, description="""The entity the annotation applies to"""
+    )
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
 
 
 class CylinderSet(Annotation, CoordMetaMixin):
@@ -1398,6 +1481,10 @@ class CylinderSet(Annotation, CoordMetaMixin):
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
     )
+    target_id: Optional[str] = Field(
+        default=None, description="""The entity the annotation applies to"""
+    )
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
 
 
 class CuboidSet(Annotation, CoordMetaMixin):
@@ -1434,6 +1521,10 @@ class CuboidSet(Annotation, CoordMetaMixin):
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
     )
+    target_id: Optional[str] = Field(
+        default=None, description="""The entity the annotation applies to"""
+    )
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
 
 
 class BoxSet(Annotation, CoordMetaMixin):
@@ -1470,6 +1561,10 @@ class BoxSet(Annotation, CoordMetaMixin):
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
     )
+    target_id: Optional[str] = Field(
+        default=None, description="""The entity the annotation applies to"""
+    )
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
 
 
 class Spline2D(Annotation, CoordMetaMixin):
@@ -1499,6 +1594,10 @@ class Spline2D(Annotation, CoordMetaMixin):
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
     )
+    target_id: Optional[str] = Field(
+        default=None, description="""The entity the annotation applies to"""
+    )
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
 
 
 class Spline3D(Annotation, CoordMetaMixin):
@@ -1528,6 +1627,10 @@ class Spline3D(Annotation, CoordMetaMixin):
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
     )
+    target_id: Optional[str] = Field(
+        default=None, description="""The entity the annotation applies to"""
+    )
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
 
 
 class DensityMap(Annotation, AssociatedFile, Image3D):
@@ -1561,12 +1664,16 @@ class DensityMap(Annotation, AssociatedFile, Image3D):
     ] = Field(
         default=[], description="""Named coordinate transformations for this entity"""
     )
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
     path: Optional[str] = Field(default=None, description="""Path to a file.""")
     annotation_type: Literal[AnnotationType.density_map] = Field(
         AnnotationType.density_map, description="""The type of annotation."""
     )
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
+    )
+    target_id: Optional[str] = Field(
+        default=None, description="""The entity the annotation applies to"""
     )
 
 
@@ -1576,6 +1683,9 @@ class Region(ConfiguredBaseModel):
     """
 
     id: str = Field(default=..., description="""Unique identifier for this entity""")
+    name: Optional[str] = Field(
+        default=None, description="""A human-readable name or title for this entity"""
+    )
     movie_stack_collection: Optional[MovieStackCollection] = Field(
         default=None, description="""The movie stack"""
     )
@@ -1623,6 +1733,7 @@ class Average(ConfiguredBaseModel):
     A particle averaging experiment.
     """
 
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
     )
@@ -1664,6 +1775,9 @@ class MovieStackCollection(ConfiguredBaseModel):
     A collection of movie stacks using the same gain and defect files.
     """
 
+    name: Optional[str] = Field(
+        default=None, description="""A human-readable name or title for this entity"""
+    )
     movie_stacks: Optional[list[MovieStackSeries]] = Field(
         default=[], description="""The movie stacks in the collection"""
     )
@@ -1683,6 +1797,7 @@ class Dataset(ConfiguredBaseModel):
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
     )
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
     regions: Optional[list[Region]] = Field(
         default=[], description="""The regions in the dataset"""
     )

--- a/src/cets_data_model/utils/validator.py
+++ b/src/cets_data_model/utils/validator.py
@@ -1,0 +1,155 @@
+"""
+Validation script for CETS dataset JSON files.
+
+Checks:
+  1. All `id` fields are unique across all objects in the document.
+  2. All `target_id` fields refer to an `id` that actually exists.
+  3. Typed reference fields refer to an `id` that exists on the correct object type:
+       - `movie_stack_id`        -> MovieStack       (lives under "stacks")
+       - `movie_stack_series_id` -> MovieStackSeries (lives under "movie_stacks")
+       - `tilt_series_id`        -> TiltSeries       (lives under "tilt_series")
+"""
+
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import List, Dict, Tuple
+
+
+# Maps reference field name -> the parent_key that identifies the expected object type
+TYPED_REFS: dict[str, str] = {
+    "movie_stack_id": "stacks",
+    "movie_stack_series_id": "movie_stacks",
+    "tilt_series_id": "tilt_series",
+}
+
+# Human-readable type names for error messages
+TYPE_NAMES: dict[str, str] = {
+    "stacks": "MovieStack",
+    "movie_stacks": "MovieStackSeries",
+    "tilt_series": "TiltSeries",
+}
+
+
+def collect(
+    obj: object,
+    parent_key: str = "",
+    path: str = "",
+    ids: dict[str, list[str]] | None = None,
+    ids_by_parent_key: dict[str, set[str]] | None = None,
+    target_ids: list[tuple[str, str]] | None = None,
+    typed_refs: list[tuple[str, str, str]] | None = None,
+) -> tuple[
+    Dict[str, list[str]],
+    Dict[str, set[str]],
+    List[tuple[str, str]],
+    List[tuple[str, str, str]],
+]:
+    """
+    Recursively walk the parsed JSON, collecting:
+      ids:               {id_value -> [paths]}
+      ids_by_parent_key: {parent_key -> {id_values}}  — for type checking
+      target_ids:        [(value, path)]
+      typed_refs:        [(field_name, value, path)]
+    """
+    if ids is None:
+        ids = defaultdict(list)
+    if ids_by_parent_key is None:
+        ids_by_parent_key = defaultdict(set)
+    if target_ids is None:
+        target_ids = []
+    if typed_refs is None:
+        typed_refs = []
+
+    if isinstance(obj, dict):
+        if "id" in obj and obj["id"] is not None:
+            id_val = str(obj["id"])
+            ids[id_val].append(path or "<root>")
+            ids_by_parent_key[parent_key].add(id_val)
+
+        if "target_id" in obj and obj["target_id"] is not None:
+            target_ids.append((str(obj["target_id"]), path or "<root>"))
+
+        for field, expected_parent_key in TYPED_REFS.items():
+            if field in obj and obj[field] is not None:
+                typed_refs.append((field, str(obj[field]), path or "<root>"))
+
+        for key, value in obj.items():
+            collect(
+                value,
+                key,
+                f"{path}.{key}",
+                ids,
+                ids_by_parent_key,
+                target_ids,
+                typed_refs,
+            )
+
+    elif isinstance(obj, list):
+        for i, item in enumerate(obj):
+            collect(
+                item,
+                parent_key,
+                f"{path}[{i}]",
+                ids,
+                ids_by_parent_key,
+                target_ids,
+                typed_refs,
+            )
+
+    return ids, ids_by_parent_key, target_ids, typed_refs
+
+
+def validate(filepath: str | Path) -> Dict[str, List[Tuple[str, str]]]:
+    path = Path(filepath)
+
+    with open(path) as f:
+        data = json.load(f)
+
+    ids, ids_by_parent_key, target_ids, typed_refs = collect(data)
+
+    errors: Dict[str, List[Tuple[str, str]]] = {}
+    known_ids = set(ids.keys())
+
+    # 1. Duplicate ids
+    for id_value, paths in ids.items():
+        if len(paths) > 1:
+            errors.setdefault("duplicate_id", []).append((id_value, ", ".join(paths)))
+
+    # 2. Unresolved target_ids
+    for target_id_value, ref_path in target_ids:
+        if target_id_value not in known_ids:
+            errors.setdefault("Unresolved target_id", []).append(
+                (target_id_value, ref_path)
+            )
+
+    # 3. Typed reference fields — must exist and point to the correct object type
+    for field, ref_value, ref_path in typed_refs:
+        expected_parent_key = TYPED_REFS[field]
+
+        if ref_value not in known_ids:
+            errors.setdefault(f"Unresolved {field}", []).append((ref_value, ref_path))
+
+        elif ref_value not in ids_by_parent_key[expected_parent_key]:
+            errors.setdefault("Wrong type", []).append(
+                (f"{field}: {ref_value!r}", ref_path)
+            )
+    return errors
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: validate_dataset.py <dataset.json> [<dataset2.json> ...]")
+        sys.exit(1)
+    return_code = 0
+    for f in sys.argv[1:]:
+        results = validate(f)
+        if results:
+            print(f"Errors found in {f}")
+            return_code = 1
+            for res in results:
+                print(res)
+                for error_item in results[res]:
+                    print(f"  {error_item}")
+    sys.exit(return_code)

--- a/tests/test_cets_models.py
+++ b/tests/test_cets_models.py
@@ -116,6 +116,7 @@ class TestRoundTripSerialization:
         """Dataset should survive JSON round-trip unchanged"""
         original = Dataset(
             name="test_dataset",
+            id="001",
             regions=[
                 Region(
                     id="region_test",
@@ -226,6 +227,7 @@ class TestConstraintValidation:
             section=0,  # Integer
             width=4096,
             height=4096,
+            id="1",
         )
         assert frame.section == 0
         assert isinstance(frame.section, int)

--- a/tests/test_data/expected_dataset.json
+++ b/tests/test_data/expected_dataset.json
@@ -1,5 +1,6 @@
 {
   "name": "example_cets_dataset",
+  "id": "999",
   "regions": [
     {
       "id": "region_01",
@@ -14,6 +15,7 @@
                 "images": [
                   {
                     "path": "/data/movies/tilt_00.tif",
+                    "id": "1",
                     "section": 0,
                     "nominal_tilt_angle": -60.0,
                     "accumulated_dose": 2.5,
@@ -45,6 +47,7 @@
                     "coordinate_transformations": []
                   },
                   {
+                    "id": "2",
                     "path": "/data/movies/tilt_00.tif",
                     "section": 1,
                     "nominal_tilt_angle": -60.0,
@@ -67,6 +70,7 @@
                 "path": "/data/movies/tilt_01.tif",
                 "images": [
                   {
+                    "id": "4",
                     "path": "/data/movies/tilt_01.tif",
                     "section": 0,
                     "nominal_tilt_angle": -30.0,
@@ -88,6 +92,7 @@
           }
         ],
         "gain_file": {
+          "id": "5",
           "path": "/data/gain_reference.mrc",
           "width": 4096,
           "height": 4096,
@@ -95,6 +100,7 @@
           "coordinate_transformations": []
         },
         "defect_file": {
+          "id": "6",
           "path": "/data/defect_map.mrc",
           "width": 4096,
           "height": 4096,
@@ -112,6 +118,7 @@
           "movie_stack_series_id": "movie_stack_series_01",
           "images": [
             {
+              "id": "7",
               "movie_stack_id": "movie_stack_01",
               "path": "/data/tilt_series/ts_01.mrc",
               "section": 0,
@@ -171,6 +178,7 @@
               ]
             },
             {
+              "id": "9",
               "movie_stack_id": "movie_stack_02",
               "path": "/data/tilt_series/ts_01.mrc",
               "section": 1,
@@ -198,6 +206,7 @@
               "name": "align_tilt_neg60",
               "input": "tilt_image_angstroms",
               "output": "tomogram_angstroms",
+              "target_id": "tomogram_01",
               "sequence": [
                 {
                   "transformation_type": "translation",
@@ -237,6 +246,7 @@
             },
             {
               "transformation_type": "projection_alignment",
+              "target_id": "tomogram_01",
               "name": "align_tilt_neg30",
               "input": "tilt_image_angstroms",
               "output": "tomogram_angstroms",
@@ -327,6 +337,7 @@
       ],
       "annotations": [
         {
+          "id": "9",
           "annotation_type": "point_set_3D",
           "name": "ribosome_picks",
           "origin3D": [
@@ -383,6 +394,7 @@
           ]
         },
         {
+          "id": "10",
           "annotation_type": "point_vector_set_3D",
           "name": "oriented_particles",
           "origin3D": [
@@ -413,6 +425,7 @@
           "coordinate_transformations": []
         },
         {
+          "id": "11",
           "annotation_type": "point_matrix_set_3D",
           "name": "rotated_particles",
           "origin3D": [
@@ -445,6 +458,7 @@
           "coordinate_transformations": []
         },
         {
+          "id": "12",
           "annotation_type": "segmentation_mask_3D",
           "name": "membrane_segmentation",
           "path": "/data/annotations/membrane_mask.mrc",
@@ -455,6 +469,7 @@
           "coordinate_transformations": []
         },
         {
+          "id": "13",
           "annotation_type": "probability_map_3D",
           "name": "ribosome_probability",
           "path": "/data/annotations/probability_map.mrc",
@@ -465,6 +480,7 @@
           "coordinate_transformations": []
         },
         {
+          "id": "14",
           "annotation_type": "point_set_2D",
           "name": "fiducial_markers",
           "origin2D": [
@@ -485,6 +501,7 @@
           "coordinate_transformations": []
         },
         {
+          "id": "15",
           "annotation_type": "tri_mesh",
           "name": "membrane_surface",
           "coordinate_systems": [],
@@ -495,6 +512,7 @@
   ],
   "averages": [
     {
+      "id": "16",
       "name": "ribosome_average_01",
       "particle_maps": [
         {
@@ -561,6 +579,7 @@
       ],
       "annotations": [
         {
+          "id": "17",
           "annotation_type": "point_set_3D",
           "name": "symmetry_points",
           "origin3D": [

--- a/tests/test_data/expected_dataset.json
+++ b/tests/test_data/expected_dataset.json
@@ -337,7 +337,6 @@
       ],
       "annotations": [
         {
-          "id": "9",
           "annotation_type": "point_set_3D",
           "name": "ribosome_picks",
           "origin3D": [
@@ -394,7 +393,6 @@
           ]
         },
         {
-          "id": "10",
           "annotation_type": "point_vector_set_3D",
           "name": "oriented_particles",
           "origin3D": [
@@ -425,7 +423,6 @@
           "coordinate_transformations": []
         },
         {
-          "id": "11",
           "annotation_type": "point_matrix_set_3D",
           "name": "rotated_particles",
           "origin3D": [
@@ -458,7 +455,6 @@
           "coordinate_transformations": []
         },
         {
-          "id": "12",
           "annotation_type": "segmentation_mask_3D",
           "name": "membrane_segmentation",
           "path": "/data/annotations/membrane_mask.mrc",
@@ -469,7 +465,6 @@
           "coordinate_transformations": []
         },
         {
-          "id": "13",
           "annotation_type": "probability_map_3D",
           "name": "ribosome_probability",
           "path": "/data/annotations/probability_map.mrc",
@@ -480,7 +475,6 @@
           "coordinate_transformations": []
         },
         {
-          "id": "14",
           "annotation_type": "point_set_2D",
           "name": "fiducial_markers",
           "origin2D": [
@@ -501,7 +495,6 @@
           "coordinate_transformations": []
         },
         {
-          "id": "15",
           "annotation_type": "tri_mesh",
           "name": "membrane_surface",
           "coordinate_systems": [],
@@ -579,7 +572,6 @@
       ],
       "annotations": [
         {
-          "id": "17",
           "annotation_type": "point_set_3D",
           "name": "symmetry_points",
           "origin3D": [

--- a/tests/test_data/expected_dataset_with_errors.json
+++ b/tests/test_data/expected_dataset_with_errors.json
@@ -1,0 +1,590 @@
+{
+  "name": "example_cets_dataset",
+  "id": "999",
+  "regions": [
+    {
+      "id": "region_01",
+      "movie_stack_collection": {
+        "movie_stacks": [
+          {
+            "id": "tomogram_01",
+            "stacks": [
+              {
+                "id": "no stack",
+                "path": "/data/movies/tilt_00.tif",
+                "images": [
+                  {
+                    "path": "/data/movies/tilt_00.tif",
+                    "id": "1",
+                    "section": 0,
+                    "nominal_tilt_angle": -60.0,
+                    "accumulated_dose": 2.5,
+                    "ctf_metadata": {
+                      "defocus_u": 25000.0,
+                      "defocus_v": 24500.0,
+                      "defocus_angle": 45.0,
+                      "defocus_handedness": -1
+                    },
+                    "width": 4096,
+                    "height": 4096,
+                    "coordinate_systems": [
+                      {
+                        "name": "movie_frame_pixels",
+                        "axes": [
+                          {
+                            "name": "x",
+                            "axis_unit": "pixel",
+                            "axis_type": "array"
+                          },
+                          {
+                            "name": "y",
+                            "axis_unit": "pixel",
+                            "axis_type": "array"
+                          }
+                        ]
+                      }
+                    ],
+                    "coordinate_transformations": []
+                  },
+                  {
+                    "id": "999",
+                    "path": "/data/movies/tilt_00.tif",
+                    "section": 1,
+                    "nominal_tilt_angle": -60.0,
+                    "accumulated_dose": 5.0,
+                    "ctf_metadata": {
+                      "defocus_u": 25000.0,
+                      "defocus_v": 24500.0,
+                      "defocus_angle": 45.0,
+                      "defocus_handedness": -1
+                    },
+                    "width": 4096,
+                    "height": 4096,
+                    "coordinate_systems": [],
+                    "coordinate_transformations": []
+                  }
+                ]
+              },
+              {
+                "id": "movie_stack_02",
+                "path": "/data/movies/tilt_01.tif",
+                "images": [
+                  {
+                    "id": "4",
+                    "path": "/data/movies/tilt_01.tif",
+                    "section": 0,
+                    "nominal_tilt_angle": -30.0,
+                    "accumulated_dose": 7.5,
+                    "ctf_metadata": {
+                      "defocus_u": 24800.0,
+                      "defocus_v": 24300.0,
+                      "defocus_angle": 46.0,
+                      "defocus_handedness": -1
+                    },
+                    "width": 4096,
+                    "height": 4096,
+                    "coordinate_systems": [],
+                    "coordinate_transformations": []
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "gain_file": {
+          "id": "5",
+          "path": "/data/gain_reference.mrc",
+          "width": 4096,
+          "height": 4096,
+          "coordinate_systems": [],
+          "coordinate_transformations": []
+        },
+        "defect_file": {
+          "id": "6",
+          "path": "/data/defect_map.mrc",
+          "width": 4096,
+          "height": 4096,
+          "coordinate_systems": [],
+          "coordinate_transformations": []
+        }
+      },
+      "tilt_series": [
+        {
+          "id": "tilt_series_01",
+          "path": "/data/tilt_series/ts_01.mrc",
+          "ctf_corrected": false,
+          "even_path": "/data/tilt_series/ts_01_even.mrc",
+          "odd_path": "/data/tilt_series/ts_01_odd.mrc",
+          "movie_stack_series_id": "movie_stack_series_01",
+          "images": [
+            {
+              "id": "7",
+              "movie_stack_id": "tomogram_01",
+              "path": "/data/tilt_series/ts_01.mrc",
+              "section": 0,
+              "nominal_tilt_angle": -60.0,
+              "accumulated_dose": 5.0,
+              "ctf_metadata": {
+                "defocus_u": 25000.0,
+                "defocus_v": 24500.0,
+                "defocus_angle": 45.0,
+                "defocus_handedness": -1
+              },
+              "width": 3840,
+              "height": 3840,
+              "coordinate_systems": [
+                {
+                  "name": "tilt_image_pixels",
+                  "axes": [
+                    {
+                      "name": "x",
+                      "axis_unit": "pixel",
+                      "axis_type": "array"
+                    },
+                    {
+                      "name": "y",
+                      "axis_unit": "pixel",
+                      "axis_type": "array"
+                    }
+                  ]
+                },
+                {
+                  "name": "tilt_image_angstroms",
+                  "axes": [
+                    {
+                      "name": "x",
+                      "axis_unit": "angstrom",
+                      "axis_type": "space"
+                    },
+                    {
+                      "name": "y",
+                      "axis_unit": "angstrom",
+                      "axis_type": "space"
+                    }
+                  ]
+                }
+              ],
+              "coordinate_transformations": [
+                {
+                  "transformation_type": "scale",
+                  "name": "pixel_to_angstrom",
+                  "input": "tilt_image_pixels",
+                  "output": "tilt_image_angstroms",
+                  "scale": [
+                    1.05,
+                    1.05
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "9",
+              "movie_stack_id": "movie_stack_02",
+              "path": "/data/tilt_series/ts_01.mrc",
+              "section": 1,
+              "nominal_tilt_angle": -30.0,
+              "accumulated_dose": 10.0,
+              "ctf_metadata": {
+                "defocus_u": 24800.0,
+                "defocus_v": 24300.0,
+                "defocus_angle": 46.0,
+                "defocus_handedness": -1
+              },
+              "width": 3840,
+              "height": 3840,
+              "coordinate_systems": [],
+              "coordinate_transformations": []
+            }
+          ]
+        }
+      ],
+      "alignments": [
+        {
+          "projection_alignments": [
+            {
+              "transformation_type": "projection_alignment",
+              "name": "align_tilt_neg60",
+              "input": "tilt_image_angstroms",
+              "output": "tomogram_angstroms",
+              "target_id": "tomogram_01",
+              "sequence": [
+                {
+                  "transformation_type": "translation",
+                  "name": "shift_to_origin",
+                  "input": "tilt_image_angstroms",
+                  "output": "tilt_centered",
+                  "translation": [
+                    -1920.0,
+                    -1920.0,
+                    0.0
+                  ]
+                },
+                {
+                  "transformation_type": "affine",
+                  "name": "rotate_and_project",
+                  "input": "tilt_centered",
+                  "output": "tomogram_angstroms",
+                  "affine": [
+                    [
+                      0.866,
+                      -0.5,
+                      0.0
+                    ],
+                    [
+                      0.5,
+                      0.866,
+                      0.0
+                    ],
+                    [
+                      0.0,
+                      0.0,
+                      1.0
+                    ]
+                  ]
+                }
+              ]
+            },
+            {
+              "transformation_type": "projection_alignment",
+              "target_id": "non-existent target",
+              "name": "align_tilt_neg30",
+              "input": "tilt_image_angstroms",
+              "output": "tomogram_angstroms",
+              "sequence": [
+                {
+                  "transformation_type": "translation",
+                  "name": "shift_to_origin",
+                  "input": "tilt_image_angstroms",
+                  "output": "tilt_centered",
+                  "translation": [
+                    -1920.0,
+                    -1920.0,
+                    0.0
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "tomograms": [
+        {
+          "id": "tomogram_01",
+          "path": "/data/tomograms/tomo_01.mrc",
+          "ctf_corrected": false,
+          "even_path": "/data/tomograms/tomo_01_even.mrc",
+          "odd_path": "/data/tomograms/tomo_01_odd.mrc",
+          "tilt_series_id": "tilt_series_01",
+          "width": 1920,
+          "height": 1920,
+          "depth": 500,
+          "coordinate_systems": [
+            {
+              "name": "tomogram_voxels",
+              "axes": [
+                {
+                  "name": "x",
+                  "axis_unit": "pixel",
+                  "axis_type": "array"
+                },
+                {
+                  "name": "y",
+                  "axis_unit": "pixel",
+                  "axis_type": "array"
+                },
+                {
+                  "name": "z",
+                  "axis_unit": "pixel",
+                  "axis_type": "array"
+                }
+              ]
+            },
+            {
+              "name": "tomogram_angstroms",
+              "axes": [
+                {
+                  "name": "x",
+                  "axis_unit": "angstrom",
+                  "axis_type": "space"
+                },
+                {
+                  "name": "y",
+                  "axis_unit": "angstrom",
+                  "axis_type": "space"
+                },
+                {
+                  "name": "z",
+                  "axis_unit": "angstrom",
+                  "axis_type": "space"
+                }
+              ]
+            }
+          ],
+          "coordinate_transformations": [
+            {
+              "transformation_type": "scale",
+              "name": "voxel_to_angstrom",
+              "input": "tomogram_voxels",
+              "output": "tomogram_angstroms",
+              "scale": [
+                10.5,
+                10.5,
+                10.5
+              ]
+            }
+          ]
+        }
+      ],
+      "annotations": [
+        {
+          "annotation_type": "point_set_3D",
+          "name": "ribosome_picks",
+          "origin3D": [
+            [
+              100.5,
+              200.3,
+              150.7
+            ],
+            [
+              305.2,
+              420.8,
+              180.1
+            ],
+            [
+              510.9,
+              630.5,
+              220.4
+            ],
+            [
+              715.3,
+              840.2,
+              260.8
+            ]
+          ],
+          "coordinate_systems": [
+            {
+              "name": "particle_coords_voxels",
+              "axes": [
+                {
+                  "name": "x",
+                  "axis_unit": "pixel",
+                  "axis_type": "array"
+                },
+                {
+                  "name": "y",
+                  "axis_unit": "pixel",
+                  "axis_type": "array"
+                },
+                {
+                  "name": "z",
+                  "axis_unit": "pixel",
+                  "axis_type": "array"
+                }
+              ]
+            }
+          ],
+          "coordinate_transformations": [
+            {
+              "transformation_type": "identity",
+              "name": "particle_to_tomogram",
+              "input": "particle_coords_voxels",
+              "output": "tomogram_voxels"
+            }
+          ]
+        },
+        {
+          "annotation_type": "point_vector_set_3D",
+          "name": "oriented_particles",
+          "origin3D": [
+            [
+              100.5,
+              200.3,
+              150.7
+            ],
+            [
+              305.2,
+              420.8,
+              180.1
+            ]
+          ],
+          "vector3D": [
+            [
+              0.707,
+              0.707,
+              0.0
+            ],
+            [
+              1.0,
+              0.0,
+              0.0
+            ]
+          ],
+          "coordinate_systems": [],
+          "coordinate_transformations": []
+        },
+        {
+          "annotation_type": "point_matrix_set_3D",
+          "name": "rotated_particles",
+          "origin3D": [
+            [
+              100.5,
+              200.3,
+              150.7
+            ]
+          ],
+          "matrix3D": [
+            [
+              [
+                1.0,
+                0.0,
+                0.0
+              ],
+              [
+                0.0,
+                0.866,
+                -0.5
+              ],
+              [
+                0.0,
+                0.5,
+                0.866
+              ]
+            ]
+          ],
+          "coordinate_systems": [],
+          "coordinate_transformations": []
+        },
+        {
+          "annotation_type": "segmentation_mask_3D",
+          "name": "membrane_segmentation",
+          "path": "/data/annotations/membrane_mask.mrc",
+          "width": 1920,
+          "height": 1920,
+          "depth": 500,
+          "coordinate_systems": [],
+          "coordinate_transformations": []
+        },
+        {
+          "annotation_type": "probability_map_3D",
+          "name": "ribosome_probability",
+          "path": "/data/annotations/probability_map.mrc",
+          "width": 1920,
+          "height": 1920,
+          "depth": 500,
+          "coordinate_systems": [],
+          "coordinate_transformations": []
+        },
+        {
+          "annotation_type": "point_set_2D",
+          "name": "fiducial_markers",
+          "origin2D": [
+            [
+              1024.5,
+              2048.3
+            ],
+            [
+              2048.7,
+              1536.9
+            ],
+            [
+              512.1,
+              3072.4
+            ]
+          ],
+          "coordinate_systems": [],
+          "coordinate_transformations": []
+        },
+        {
+          "annotation_type": "tri_mesh",
+          "name": "membrane_surface",
+          "coordinate_systems": [],
+          "coordinate_transformations": []
+        }
+      ]
+    }
+  ],
+  "averages": [
+    {
+      "id": "16",
+      "name": "ribosome_average_01",
+      "particle_maps": [
+        {
+          "path": "/data/averages/ribosome_map.mrc",
+          "width": 256,
+          "height": 256,
+          "depth": 256,
+          "coordinate_systems": [
+            {
+              "name": "particle_map_voxels",
+              "axes": [
+                {
+                  "name": "x",
+                  "axis_unit": "pixel",
+                  "axis_type": "array"
+                },
+                {
+                  "name": "y",
+                  "axis_unit": "pixel",
+                  "axis_type": "array"
+                },
+                {
+                  "name": "z",
+                  "axis_unit": "pixel",
+                  "axis_type": "array"
+                }
+              ]
+            },
+            {
+              "name": "particle_map_angstroms",
+              "axes": [
+                {
+                  "name": "x",
+                  "axis_unit": "angstrom",
+                  "axis_type": "space"
+                },
+                {
+                  "name": "y",
+                  "axis_unit": "angstrom",
+                  "axis_type": "space"
+                },
+                {
+                  "name": "z",
+                  "axis_unit": "angstrom",
+                  "axis_type": "space"
+                }
+              ]
+            }
+          ],
+          "coordinate_transformations": [
+            {
+              "transformation_type": "scale",
+              "name": "particle_voxel_to_angstrom",
+              "input": "particle_map_voxels",
+              "output": "particle_map_angstroms",
+              "scale": [
+                1.5,
+                1.5,
+                1.5
+              ]
+            }
+          ]
+        }
+      ],
+      "annotations": [
+        {
+          "annotation_type": "point_set_3D",
+          "name": "symmetry_points",
+          "origin3D": [
+            [
+              128.0,
+              128.0,
+              128.0
+            ]
+          ],
+          "coordinate_systems": [],
+          "coordinate_transformations": []
+        }
+      ]
+    }
+  ]
+}

--- a/tests/test_model_gen.py
+++ b/tests/test_model_gen.py
@@ -174,6 +174,7 @@ def test_discriminated_union_validation_works(models_path):
             Identity(name="identity_transform"),
             Scale(scale=[2.0, 2.0], name="scale_transform"),
         ],
+        id="1",
     )
 
     assert len(img.coordinate_transformations) == 2

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,6 +18,7 @@ from src.cets_data_model.utils.coordinate_systems import (
 )
 from cets_data_model.models.models import CoordinateSystem
 from tests.testing_tools import CetsDataModelTest
+from src.cets_data_model.utils.validator import validate
 
 
 class UtilsTests(CetsDataModelTest):
@@ -107,6 +108,44 @@ class UtilsTests(CetsDataModelTest):
     def test_make_coordinate_system_bad_dims_physical(self):
         with self.assertRaises(ValueError):
             physical_coords(dim=1, name="bad")
+
+
+class ValidatorTests(CetsDataModelTest):
+    def test_validate_file_no_errors(self):
+        file = self.test_data / "expected_dataset.json"
+        assert validate(file) == {}
+
+    def test_validate_file_with_errors(self):
+        file = self.test_data / "expected_dataset_with_errors.json"
+        assert validate(file) == {
+            "Unresolved movie_stack_series_id": [
+                ("movie_stack_series_01", ".regions[0].tilt_series[0]")
+            ],
+            "Unresolved target_id": [
+                (
+                    "non-existent target",
+                    ".regions[0].alignments[0].projection_alignments[1]",
+                )
+            ],
+            "Wrong type": [
+                (
+                    "movie_stack_id: 'tomogram_01'",
+                    ".regions[0].tilt_series[0].images[0]",
+                )
+            ],
+            "duplicate_id": [
+                (
+                    "999",
+                    "<root>, "
+                    ".regions[0].movie_stack_collection.movie_stacks[0].stacks[0].images[1]",
+                ),
+                (
+                    "tomogram_01",
+                    ".regions[0].movie_stack_collection.movie_stacks[0], "
+                    ".regions[0].tomograms[0]",
+                ),
+            ],
+        }
 
 
 def test_make_coordinate_system_2d_logical():


### PR DESCRIPTION
Added `id` fields to many entries.

Added `target_id` field to only the `Sequence` transformation.

The rationale behind this is it doesn't make a lot of sense to have a target on some of the transforms EG: scale for pixel size. So when going from one object to another all the individual transformation are in the `transformations` field of a singel `Sequence` trasformation object, but only the main object needs to point to the target.

A side effect of this is that when going between two objects where only a single transformation is required it still needs to be in a `Sequence` just one that contains a single transformation.

Also added a validator in utils that checkes:
1) all `id` fields are unique
2) Anything that references an `id` field refererences an `id` the exists and is of the right type (if applicable)