### PR TITLE
Jj align ti ids

### DIFF
--- a/model_processing/patch_config.yaml
+++ b/model_processing/patch_config.yaml
@@ -1,5 +1,7 @@
 discriminated_fields:
   - field_name: annotations
+    for_classes:
+      - Region
     discriminator: annotation_type
     union_types:
       - SegmentationMask2D

--- a/schema/linkml/alignment.yaml
+++ b/schema/linkml/alignment.yaml
@@ -13,15 +13,23 @@ default_prefix: alignment
 imports:
 - linkml:types
 - ./coordinate_transforms
+- ./common
 
 classes:
   ProjectionAlignment:
     is_a: CoordinateTransformation
     description: The tomographic alignment for a single projection.
+    slots:
+      - id
     slot_usage:
       transformation_type:
         ifabsent: TransformationType(projection_alignment)
     attributes:
+      tilt_image_id:
+        description: >-
+          ID of the tilt-image this alignment applies to. Multiple alignments (e.g. produced 
+          by different algorithms) may reference the same tilt-image.
+        range: string
       sequence:
         description: The sequence of transformations
         range: CoordinateTransformation
@@ -34,10 +42,16 @@ classes:
   Alignment:
     description: The tomographic alignment for a tilt series.
     attributes:
+        tilt_series_id:
+          description: >-
+            ID of the tilt-series this alignment set applies to. Multiple Alignments (e.g. 
+            from different algorithms) may reference the same tilt-series.
+          range: string
         projection_alignments:
           description: alignment for a specific projection
           range: ProjectionAlignment
           multivalued: true
+          inlined_as_list: true
 
 
 

--- a/schema/linkml/annotation.yaml
+++ b/schema/linkml/annotation.yaml
@@ -21,6 +21,9 @@ slots:
       description: The type of annotation.
       range: AnnotationType
       required: true
+  - source_tomogram_id:
+      description: ID of the tomogram from which this annotation was derived, such as the tomogram containing picked coordinates.
+      range: string
   - origin2D:
       description: Location on a 2D image (Nx2).
       range: float
@@ -149,8 +152,10 @@ classes:
   Annotation:
     description: A primitive annotation.
     slots:
+      - id
       - annotation_type
       - name
+      - source_tomogram_id
   SegmentationMask2D:
     is_a: Annotation
     mixins:

--- a/schema/linkml/entities.yaml
+++ b/schema/linkml/entities.yaml
@@ -17,6 +17,14 @@ imports:
 - ./annotation
 - ./common
 
+slots:
+  source_region_id:
+    description: ID of the region containing the source annotation.
+    range: string
+  source_annotation_id:
+    description: ID of the source annotation inside the referenced region.
+    range: string
+
 classes:
   Region:
     description: Raw data (movie stacks) and derived data (tilt series, tomograms, annotations) from a single region of
@@ -46,6 +54,13 @@ classes:
         range: Annotation
         multivalued: true
 
+  AnnotationReference:
+    description: A reference from an average to an annotation stored in a region.
+    slots:
+      - id
+      - source_region_id
+      - source_annotation_id
+
   Average:
     description: A particle averaging experiment.
     slots:
@@ -56,9 +71,10 @@ classes:
         range: ParticleMap
         multivalued: true
       annotations:
-        description: The annotations
-        range: Annotation
+        description: The source annotations used by this average.
+        range: AnnotationReference
         multivalued: true
+        inlined_as_list: true
 
   MovieStackCollection:
     description: A collection of movie stacks using the same gain and defect files.

--- a/schema/linkml/image_entities.yaml
+++ b/schema/linkml/image_entities.yaml
@@ -43,6 +43,12 @@ slots:
   particle_index:
     description: Index of a particle inside a tomogram.
     range: integer
+  source_annotation_reference_id:
+    description: ID of the average-local annotation reference containing the coordinate used to extract this particle map.
+    range: string
+  coord_index:
+    description: 0-based index of the coordinate inside the resolved source annotation.
+    range: integer
   ctf_metadata:
     description: A set of CTF patameters for an image.
     range: CTFMetadata
@@ -175,7 +181,8 @@ classes:
     description: A 3D particle density map.
     slots:
       - path
-
+      - source_annotation_reference_id
+      - coord_index
 
 
 

--- a/schema/linkml/image_entities.yaml
+++ b/schema/linkml/image_entities.yaml
@@ -142,6 +142,8 @@ classes:
   TiltImage:
     is_a: BaseProjectionImage
     description: A projection image that belongs to a tilt series.
+    slots:
+      - id
     attributes:
       movie_stack_id:
         description: The ID of the movie stack for this tilt image.

--- a/src/cets_data_model/models/models.py
+++ b/src/cets_data_model/models/models.py
@@ -455,6 +455,11 @@ class ProjectionAlignment(CoordinateTransformation):
     The tomographic alignment for a single projection.
     """
 
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
+    tilt_image_id: Optional[str] = Field(
+        default=None,
+        description="""ID of the tilt-image this alignment applies to. Multiple alignments (e.g. produced  by different algorithms) may reference the same tilt-image.""",
+    )
     sequence: Optional[list[Union[Affine, Translation]]] = Field(
         default=[], description="""The sequence of transformations""", max_length=2
     )
@@ -478,6 +483,10 @@ class Alignment(ConfiguredBaseModel):
     The tomographic alignment for a tilt series.
     """
 
+    tilt_series_id: Optional[str] = Field(
+        default=None,
+        description="""ID of the tilt-series this alignment set applies to. Multiple Alignments (e.g.  from different algorithms) may reference the same tilt-series.""",
+    )
     projection_alignments: Optional[list[ProjectionAlignment]] = Field(
         default=[], description="""alignment for a specific projection"""
     )
@@ -770,6 +779,7 @@ class TiltImage(BaseProjectionImage):
     A projection image that belongs to a tilt series.
     """
 
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
     movie_stack_id: Optional[str] = Field(
         default=None, description="""The ID of the movie stack for this tilt image."""
     )

--- a/src/cets_data_model/models/models.py
+++ b/src/cets_data_model/models/models.py
@@ -884,6 +884,14 @@ class ParticleMap(Image3D):
     """
 
     path: Optional[str] = Field(default=None, description="""Path to a file.""")
+    source_annotation_reference_id: Optional[str] = Field(
+        default=None,
+        description="""ID of the average-local annotation reference containing the coordinate used to extract this particle map.""",
+    )
+    coord_index: Optional[int] = Field(
+        default=None,
+        description="""0-based index of the coordinate inside the resolved source annotation.""",
+    )
     width: Optional[int] = Field(
         default=None, description="""The width of the image (x-axis) in pixels"""
     )
@@ -941,11 +949,16 @@ class Annotation(ConfiguredBaseModel):
     A primitive annotation.
     """
 
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
     annotation_type: AnnotationType = Field(
         default=..., description="""The type of annotation."""
     )
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
+    )
+    source_tomogram_id: Optional[str] = Field(
+        default=None,
+        description="""ID of the tomogram this annotation was derived from, such as the tomogram containing picked coordinates.""",
     )
 
 
@@ -974,11 +987,16 @@ class SegmentationMask2D(Annotation, AssociatedFile, Image2D):
         default=[], description="""Named coordinate transformations for this entity"""
     )
     path: Optional[str] = Field(default=None, description="""Path to a file.""")
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
     annotation_type: Literal[AnnotationType.segmentation_mask_2D] = Field(
         AnnotationType.segmentation_mask_2D, description="""The type of annotation."""
     )
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
+    )
+    source_tomogram_id: Optional[str] = Field(
+        default=None,
+        description="""ID of the tomogram this annotation was derived from, such as the tomogram containing picked coordinates.""",
     )
 
 
@@ -1010,11 +1028,16 @@ class SegmentationMask3D(Annotation, AssociatedFile, Image3D):
         default=[], description="""Named coordinate transformations for this entity"""
     )
     path: Optional[str] = Field(default=None, description="""Path to a file.""")
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
     annotation_type: Literal[AnnotationType.segmentation_mask_3D] = Field(
         AnnotationType.segmentation_mask_3D, description="""The type of annotation."""
     )
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
+    )
+    source_tomogram_id: Optional[str] = Field(
+        default=None,
+        description="""ID of the tomogram this annotation was derived from, such as the tomogram containing picked coordinates.""",
     )
 
 
@@ -1043,11 +1066,16 @@ class ProbabilityMap2D(Annotation, AssociatedFile, Image2D):
         default=[], description="""Named coordinate transformations for this entity"""
     )
     path: Optional[str] = Field(default=None, description="""Path to a file.""")
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
     annotation_type: Literal[AnnotationType.probability_map_2D] = Field(
         AnnotationType.probability_map_2D, description="""The type of annotation."""
     )
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
+    )
+    source_tomogram_id: Optional[str] = Field(
+        default=None,
+        description="""ID of the tomogram this annotation was derived from, such as the tomogram containing picked coordinates.""",
     )
 
 
@@ -1079,11 +1107,16 @@ class ProbabilityMap3D(Annotation, AssociatedFile, Image3D):
         default=[], description="""Named coordinate transformations for this entity"""
     )
     path: Optional[str] = Field(default=None, description="""Path to a file.""")
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
     annotation_type: Literal[AnnotationType.probability_map_3D] = Field(
         AnnotationType.probability_map_3D, description="""The type of annotation."""
     )
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
+    )
+    source_tomogram_id: Optional[str] = Field(
+        default=None,
+        description="""ID of the tomogram this annotation was derived from, such as the tomogram containing picked coordinates.""",
     )
 
 
@@ -1108,11 +1141,16 @@ class PointSet2D(Annotation, CoordMetaMixin):
     ] = Field(
         default=[], description="""Named coordinate transformations for this entity"""
     )
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
     annotation_type: Literal[AnnotationType.point_set_2D] = Field(
         AnnotationType.point_set_2D, description="""The type of annotation."""
     )
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
+    )
+    source_tomogram_id: Optional[str] = Field(
+        default=None,
+        description="""ID of the tomogram this annotation was derived from, such as the tomogram containing picked coordinates.""",
     )
 
 
@@ -1137,11 +1175,16 @@ class PointSet3D(Annotation, CoordMetaMixin):
     ] = Field(
         default=[], description="""Named coordinate transformations for this entity"""
     )
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
     annotation_type: Literal[AnnotationType.point_set_3D] = Field(
         AnnotationType.point_set_3D, description="""The type of annotation."""
     )
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
+    )
+    source_tomogram_id: Optional[str] = Field(
+        default=None,
+        description="""ID of the tomogram this annotation was derived from, such as the tomogram containing picked coordinates.""",
     )
 
 
@@ -1170,11 +1213,16 @@ class PointVectorSet2D(Annotation, CoordMetaMixin):
     ] = Field(
         default=[], description="""Named coordinate transformations for this entity"""
     )
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
     annotation_type: Literal[AnnotationType.point_vector_set_2D] = Field(
         AnnotationType.point_vector_set_2D, description="""The type of annotation."""
     )
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
+    )
+    source_tomogram_id: Optional[str] = Field(
+        default=None,
+        description="""ID of the tomogram this annotation was derived from, such as the tomogram containing picked coordinates.""",
     )
 
 
@@ -1203,11 +1251,16 @@ class PointVectorSet3D(Annotation, CoordMetaMixin):
     ] = Field(
         default=[], description="""Named coordinate transformations for this entity"""
     )
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
     annotation_type: Literal[AnnotationType.point_vector_set_3D] = Field(
         AnnotationType.point_vector_set_3D, description="""The type of annotation."""
     )
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
+    )
+    source_tomogram_id: Optional[str] = Field(
+        default=None,
+        description="""ID of the tomogram this annotation was derived from, such as the tomogram containing picked coordinates.""",
     )
 
 
@@ -1236,11 +1289,16 @@ class PointMatrixSet2D(Annotation, CoordMetaMixin):
     ] = Field(
         default=[], description="""Named coordinate transformations for this entity"""
     )
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
     annotation_type: Literal[AnnotationType.point_matrix_set_2D] = Field(
         AnnotationType.point_matrix_set_2D, description="""The type of annotation."""
     )
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
+    )
+    source_tomogram_id: Optional[str] = Field(
+        default=None,
+        description="""ID of the tomogram this annotation was derived from, such as the tomogram containing picked coordinates.""",
     )
 
 
@@ -1269,11 +1327,16 @@ class PointMatrixSet3D(Annotation, CoordMetaMixin):
     ] = Field(
         default=[], description="""Named coordinate transformations for this entity"""
     )
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
     annotation_type: Literal[AnnotationType.point_matrix_set_3D] = Field(
         AnnotationType.point_matrix_set_3D, description="""The type of annotation."""
     )
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
+    )
+    source_tomogram_id: Optional[str] = Field(
+        default=None,
+        description="""ID of the tomogram this annotation was derived from, such as the tomogram containing picked coordinates.""",
     )
 
 
@@ -1295,11 +1358,16 @@ class TriMesh(Annotation, CoordMetaMixin):
     ] = Field(
         default=[], description="""Named coordinate transformations for this entity"""
     )
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
     annotation_type: Literal[AnnotationType.tri_mesh] = Field(
         AnnotationType.tri_mesh, description="""The type of annotation."""
     )
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
+    )
+    source_tomogram_id: Optional[str] = Field(
+        default=None,
+        description="""ID of the tomogram this annotation was derived from, such as the tomogram containing picked coordinates.""",
     )
 
 
@@ -1327,11 +1395,16 @@ class SphereSet(Annotation, CoordMetaMixin):
     ] = Field(
         default=[], description="""Named coordinate transformations for this entity"""
     )
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
     annotation_type: Literal[AnnotationType.sphere_set] = Field(
         AnnotationType.sphere_set, description="""The type of annotation."""
     )
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
+    )
+    source_tomogram_id: Optional[str] = Field(
+        default=None,
+        description="""ID of the tomogram this annotation was derived from, such as the tomogram containing picked coordinates.""",
     )
 
 
@@ -1359,11 +1432,16 @@ class CircleSet(Annotation, CoordMetaMixin):
     ] = Field(
         default=[], description="""Named coordinate transformations for this entity"""
     )
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
     annotation_type: Literal[AnnotationType.circle_set] = Field(
         AnnotationType.circle_set, description="""The type of annotation."""
     )
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
+    )
+    source_tomogram_id: Optional[str] = Field(
+        default=None,
+        description="""ID of the tomogram this annotation was derived from, such as the tomogram containing picked coordinates.""",
     )
 
 
@@ -1392,11 +1470,16 @@ class CylinderSet(Annotation, CoordMetaMixin):
     ] = Field(
         default=[], description="""Named coordinate transformations for this entity"""
     )
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
     annotation_type: Literal[AnnotationType.cylinder_set] = Field(
         AnnotationType.cylinder_set, description="""The type of annotation."""
     )
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
+    )
+    source_tomogram_id: Optional[str] = Field(
+        default=None,
+        description="""ID of the tomogram this annotation was derived from, such as the tomogram containing picked coordinates.""",
     )
 
 
@@ -1428,11 +1511,16 @@ class CuboidSet(Annotation, CoordMetaMixin):
     ] = Field(
         default=[], description="""Named coordinate transformations for this entity"""
     )
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
     annotation_type: Literal[AnnotationType.cuboid_set] = Field(
         AnnotationType.cuboid_set, description="""The type of annotation."""
     )
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
+    )
+    source_tomogram_id: Optional[str] = Field(
+        default=None,
+        description="""ID of the tomogram this annotation was derived from, such as the tomogram containing picked coordinates.""",
     )
 
 
@@ -1464,11 +1552,16 @@ class BoxSet(Annotation, CoordMetaMixin):
     ] = Field(
         default=[], description="""Named coordinate transformations for this entity"""
     )
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
     annotation_type: Literal[AnnotationType.box_set] = Field(
         AnnotationType.box_set, description="""The type of annotation."""
     )
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
+    )
+    source_tomogram_id: Optional[str] = Field(
+        default=None,
+        description="""ID of the tomogram this annotation was derived from, such as the tomogram containing picked coordinates.""",
     )
 
 
@@ -1493,11 +1586,16 @@ class Spline2D(Annotation, CoordMetaMixin):
     ] = Field(
         default=[], description="""Named coordinate transformations for this entity"""
     )
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
     annotation_type: Literal[AnnotationType.spline_2D] = Field(
         AnnotationType.spline_2D, description="""The type of annotation."""
     )
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
+    )
+    source_tomogram_id: Optional[str] = Field(
+        default=None,
+        description="""ID of the tomogram this annotation was derived from, such as the tomogram containing picked coordinates.""",
     )
 
 
@@ -1522,11 +1620,16 @@ class Spline3D(Annotation, CoordMetaMixin):
     ] = Field(
         default=[], description="""Named coordinate transformations for this entity"""
     )
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
     annotation_type: Literal[AnnotationType.spline_3D] = Field(
         AnnotationType.spline_3D, description="""The type of annotation."""
     )
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
+    )
+    source_tomogram_id: Optional[str] = Field(
+        default=None,
+        description="""ID of the tomogram this annotation was derived from, such as the tomogram containing picked coordinates.""",
     )
 
 
@@ -1562,11 +1665,16 @@ class DensityMap(Annotation, AssociatedFile, Image3D):
         default=[], description="""Named coordinate transformations for this entity"""
     )
     path: Optional[str] = Field(default=None, description="""Path to a file.""")
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
     annotation_type: Literal[AnnotationType.density_map] = Field(
         AnnotationType.density_map, description="""The type of annotation."""
     )
     name: Optional[str] = Field(
         default=None, description="""A human-readable name or title for this entity"""
+    )
+    source_tomogram_id: Optional[str] = Field(
+        default=None,
+        description="""ID of the tomogram this annotation was derived from, such as the tomogram containing picked coordinates.""",
     )
 
 
@@ -1618,6 +1726,22 @@ class Region(ConfiguredBaseModel):
     ] = Field(default=[], description="""The annotations for this region""")
 
 
+class AnnotationReference(ConfiguredBaseModel):
+    """
+    A reference from an average to an annotation stored in a region.
+    """
+
+    id: str = Field(default=..., description="""Unique identifier for this entity""")
+    source_region_id: Optional[str] = Field(
+        default=None,
+        description="""ID of the region containing the source annotation.""",
+    )
+    source_annotation_id: Optional[str] = Field(
+        default=None,
+        description="""ID of the source annotation inside the referenced region.""",
+    )
+
+
 class Average(ConfiguredBaseModel):
     """
     A particle averaging experiment.
@@ -1629,34 +1753,9 @@ class Average(ConfiguredBaseModel):
     particle_maps: Optional[list[ParticleMap]] = Field(
         default=[], description="""The particle maps"""
     )
-    annotations: Optional[
-        list[
-            Annotated[
-                Union[
-                    SegmentationMask2D,
-                    SegmentationMask3D,
-                    ProbabilityMap2D,
-                    ProbabilityMap3D,
-                    PointSet2D,
-                    PointSet3D,
-                    PointVectorSet2D,
-                    PointVectorSet3D,
-                    PointMatrixSet2D,
-                    PointMatrixSet3D,
-                    TriMesh,
-                    SphereSet,
-                    CircleSet,
-                    CylinderSet,
-                    CuboidSet,
-                    BoxSet,
-                    Spline2D,
-                    Spline3D,
-                    DensityMap,
-                ],
-                Field(discriminator="annotation_type"),
-            ]
-        ]
-    ] = Field(default=[], description="""The annotations""")
+    annotations: Optional[list[AnnotationReference]] = Field(
+        default=[], description="""The source annotations used by this average."""
+    )
 
 
 class MovieStackCollection(ConfiguredBaseModel):
@@ -1746,6 +1845,7 @@ Spline2D.model_rebuild()
 Spline3D.model_rebuild()
 DensityMap.model_rebuild()
 Region.model_rebuild()
+AnnotationReference.model_rebuild()
 Average.model_rebuild()
 MovieStackCollection.model_rebuild()
 Dataset.model_rebuild()

--- a/src/cets_data_model/models/models.py
+++ b/src/cets_data_model/models/models.py
@@ -958,7 +958,7 @@ class Annotation(ConfiguredBaseModel):
     )
     source_tomogram_id: Optional[str] = Field(
         default=None,
-        description="""ID of the tomogram this annotation was derived from, such as the tomogram containing picked coordinates.""",
+        description="""ID of the tomogram from which this annotation was derived, such as the tomogram containing picked coordinates.""",
     )
 
 
@@ -996,7 +996,7 @@ class SegmentationMask2D(Annotation, AssociatedFile, Image2D):
     )
     source_tomogram_id: Optional[str] = Field(
         default=None,
-        description="""ID of the tomogram this annotation was derived from, such as the tomogram containing picked coordinates.""",
+        description="""ID of the tomogram from which this annotation was derived, such as the tomogram containing picked coordinates.""",
     )
 
 
@@ -1037,7 +1037,7 @@ class SegmentationMask3D(Annotation, AssociatedFile, Image3D):
     )
     source_tomogram_id: Optional[str] = Field(
         default=None,
-        description="""ID of the tomogram this annotation was derived from, such as the tomogram containing picked coordinates.""",
+        description="""ID of the tomogram from which this annotation was derived, such as the tomogram containing picked coordinates.""",
     )
 
 
@@ -1075,7 +1075,7 @@ class ProbabilityMap2D(Annotation, AssociatedFile, Image2D):
     )
     source_tomogram_id: Optional[str] = Field(
         default=None,
-        description="""ID of the tomogram this annotation was derived from, such as the tomogram containing picked coordinates.""",
+        description="""ID of the tomogram from which this annotation was derived, such as the tomogram containing picked coordinates.""",
     )
 
 
@@ -1116,7 +1116,7 @@ class ProbabilityMap3D(Annotation, AssociatedFile, Image3D):
     )
     source_tomogram_id: Optional[str] = Field(
         default=None,
-        description="""ID of the tomogram this annotation was derived from, such as the tomogram containing picked coordinates.""",
+        description="""ID of the tomogram from which this annotation was derived, such as the tomogram containing picked coordinates.""",
     )
 
 
@@ -1150,7 +1150,7 @@ class PointSet2D(Annotation, CoordMetaMixin):
     )
     source_tomogram_id: Optional[str] = Field(
         default=None,
-        description="""ID of the tomogram this annotation was derived from, such as the tomogram containing picked coordinates.""",
+        description="""ID of the tomogram from which this annotation was derived, such as the tomogram containing picked coordinates.""",
     )
 
 
@@ -1184,7 +1184,7 @@ class PointSet3D(Annotation, CoordMetaMixin):
     )
     source_tomogram_id: Optional[str] = Field(
         default=None,
-        description="""ID of the tomogram this annotation was derived from, such as the tomogram containing picked coordinates.""",
+        description="""ID of the tomogram from which this annotation was derived, such as the tomogram containing picked coordinates.""",
     )
 
 
@@ -1222,7 +1222,7 @@ class PointVectorSet2D(Annotation, CoordMetaMixin):
     )
     source_tomogram_id: Optional[str] = Field(
         default=None,
-        description="""ID of the tomogram this annotation was derived from, such as the tomogram containing picked coordinates.""",
+        description="""ID of the tomogram from which this annotation was derived, such as the tomogram containing picked coordinates.""",
     )
 
 
@@ -1260,7 +1260,7 @@ class PointVectorSet3D(Annotation, CoordMetaMixin):
     )
     source_tomogram_id: Optional[str] = Field(
         default=None,
-        description="""ID of the tomogram this annotation was derived from, such as the tomogram containing picked coordinates.""",
+        description="""ID of the tomogram from which this annotation was derived, such as the tomogram containing picked coordinates.""",
     )
 
 
@@ -1298,7 +1298,7 @@ class PointMatrixSet2D(Annotation, CoordMetaMixin):
     )
     source_tomogram_id: Optional[str] = Field(
         default=None,
-        description="""ID of the tomogram this annotation was derived from, such as the tomogram containing picked coordinates.""",
+        description="""ID of the tomogram from which this annotation was derived, such as the tomogram containing picked coordinates.""",
     )
 
 
@@ -1336,7 +1336,7 @@ class PointMatrixSet3D(Annotation, CoordMetaMixin):
     )
     source_tomogram_id: Optional[str] = Field(
         default=None,
-        description="""ID of the tomogram this annotation was derived from, such as the tomogram containing picked coordinates.""",
+        description="""ID of the tomogram from which this annotation was derived, such as the tomogram containing picked coordinates.""",
     )
 
 
@@ -1367,7 +1367,7 @@ class TriMesh(Annotation, CoordMetaMixin):
     )
     source_tomogram_id: Optional[str] = Field(
         default=None,
-        description="""ID of the tomogram this annotation was derived from, such as the tomogram containing picked coordinates.""",
+        description="""ID of the tomogram from which this annotation was derived, such as the tomogram containing picked coordinates.""",
     )
 
 
@@ -1404,7 +1404,7 @@ class SphereSet(Annotation, CoordMetaMixin):
     )
     source_tomogram_id: Optional[str] = Field(
         default=None,
-        description="""ID of the tomogram this annotation was derived from, such as the tomogram containing picked coordinates.""",
+        description="""ID of the tomogram from which this annotation was derived, such as the tomogram containing picked coordinates.""",
     )
 
 
@@ -1441,7 +1441,7 @@ class CircleSet(Annotation, CoordMetaMixin):
     )
     source_tomogram_id: Optional[str] = Field(
         default=None,
-        description="""ID of the tomogram this annotation was derived from, such as the tomogram containing picked coordinates.""",
+        description="""ID of the tomogram from which this annotation was derived, such as the tomogram containing picked coordinates.""",
     )
 
 
@@ -1479,7 +1479,7 @@ class CylinderSet(Annotation, CoordMetaMixin):
     )
     source_tomogram_id: Optional[str] = Field(
         default=None,
-        description="""ID of the tomogram this annotation was derived from, such as the tomogram containing picked coordinates.""",
+        description="""ID of the tomogram from which this annotation was derived, such as the tomogram containing picked coordinates.""",
     )
 
 
@@ -1520,7 +1520,7 @@ class CuboidSet(Annotation, CoordMetaMixin):
     )
     source_tomogram_id: Optional[str] = Field(
         default=None,
-        description="""ID of the tomogram this annotation was derived from, such as the tomogram containing picked coordinates.""",
+        description="""ID of the tomogram from which this annotation was derived, such as the tomogram containing picked coordinates.""",
     )
 
 
@@ -1561,7 +1561,7 @@ class BoxSet(Annotation, CoordMetaMixin):
     )
     source_tomogram_id: Optional[str] = Field(
         default=None,
-        description="""ID of the tomogram this annotation was derived from, such as the tomogram containing picked coordinates.""",
+        description="""ID of the tomogram from which this annotation was derived, such as the tomogram containing picked coordinates.""",
     )
 
 
@@ -1595,7 +1595,7 @@ class Spline2D(Annotation, CoordMetaMixin):
     )
     source_tomogram_id: Optional[str] = Field(
         default=None,
-        description="""ID of the tomogram this annotation was derived from, such as the tomogram containing picked coordinates.""",
+        description="""ID of the tomogram from which this annotation was derived, such as the tomogram containing picked coordinates.""",
     )
 
 
@@ -1629,7 +1629,7 @@ class Spline3D(Annotation, CoordMetaMixin):
     )
     source_tomogram_id: Optional[str] = Field(
         default=None,
-        description="""ID of the tomogram this annotation was derived from, such as the tomogram containing picked coordinates.""",
+        description="""ID of the tomogram from which this annotation was derived, such as the tomogram containing picked coordinates.""",
     )
 
 
@@ -1674,7 +1674,7 @@ class DensityMap(Annotation, AssociatedFile, Image3D):
     )
     source_tomogram_id: Optional[str] = Field(
         default=None,
-        description="""ID of the tomogram this annotation was derived from, such as the tomogram containing picked coordinates.""",
+        description="""ID of the tomogram from which this annotation was derived, such as the tomogram containing picked coordinates.""",
     )
 
 

--- a/tests/test_cets_models.py
+++ b/tests/test_cets_models.py
@@ -16,6 +16,7 @@ from cets_data_model.models.models import (
     Sequence,
     PointSet3D,
     ParticleMap,
+    Average,
     AnnotationReference,
 )
 
@@ -211,6 +212,28 @@ class TestRoundTripSerialization:
 
         assert reconstructed.source_annotation_reference_id == "average_ribosome_picks"
         assert reconstructed.coord_index == 3
+
+    def test_average_without_annotation_references_roundtrip(self):
+        """Averages may contain particle maps without source annotation references"""
+        original = Average(
+            name="subtomograms_only",
+            particle_maps=[
+                ParticleMap(
+                    path="/data/subtomograms/particle_001.mrc",
+                    width=64,
+                    height=64,
+                    depth=64,
+                )
+            ],
+        )
+
+        json_str = original.model_dump_json()
+        reconstructed = Average.model_validate_json(json_str)
+
+        assert len(reconstructed.particle_maps) == 1
+        assert reconstructed.annotations == []
+        assert reconstructed.particle_maps[0].source_annotation_reference_id is None
+        assert reconstructed.particle_maps[0].coord_index is None
 
     def test_transformation_sequence_roundtrip(self):
         """Complex transformation sequences should survive round-trip"""

--- a/tests/test_cets_models.py
+++ b/tests/test_cets_models.py
@@ -15,6 +15,8 @@ from cets_data_model.models.models import (
     Affine,
     Sequence,
     PointSet3D,
+    ParticleMap,
+    AnnotationReference,
 )
 
 
@@ -68,6 +70,7 @@ class TestExpectedDatasetValidation:
         region = dataset.regions[0]
 
         annotation_types = {ann.annotation_type for ann in region.annotations}
+        annotation_ids = {ann.id for ann in region.annotations}
 
         # TODO: add new annotation types
         expected_types = {
@@ -81,6 +84,17 @@ class TestExpectedDatasetValidation:
         }
 
         assert annotation_types == expected_types
+        assert "ribosome_picks" in annotation_ids
+        assert region.annotations[0].source_tomogram_id == "tomogram_01"
+
+        average = dataset.averages[0]
+        assert average.annotations[0].id == "average_ribosome_picks"
+        assert average.annotations[0].source_region_id == "region_01"
+        assert average.annotations[0].source_annotation_id == "ribosome_picks"
+        assert (
+            average.particle_maps[0].source_annotation_reference_id
+            == "average_ribosome_picks"
+        )
 
     def test_expected_dataset_transformations(self, expected_dataset_path):
         """Verify transformation types are present"""
@@ -142,7 +156,9 @@ class TestRoundTripSerialization:
     def test_annotation_roundtrip(self):
         """Annotations should survive round-trip with all fields"""
         original = PointSet3D(
+            id="particle_coords_annotation",
             annotation_type="point_set_3D",
+            source_tomogram_id="tomogram_01",
             origin3D=[[100.0, 200.0, 300.0], [150.0, 250.0, 350.0]],
             coordinate_systems=[
                 CoordinateSystem(
@@ -162,6 +178,39 @@ class TestRoundTripSerialization:
         assert original.model_dump() == reconstructed.model_dump()
         assert len(reconstructed.origin3D) == 2
         assert reconstructed.coordinate_systems[0].name == "particle_coords"
+        assert reconstructed.source_tomogram_id == "tomogram_01"
+
+    def test_annotation_reference_roundtrip(self):
+        """Annotation references should preserve region and annotation IDs"""
+        original = AnnotationReference(
+            id="average_ribosome_picks",
+            source_region_id="region_01",
+            source_annotation_id="ribosome_picks",
+        )
+
+        json_str = original.model_dump_json()
+        reconstructed = AnnotationReference.model_validate_json(json_str)
+
+        assert reconstructed.id == "average_ribosome_picks"
+        assert reconstructed.source_region_id == "region_01"
+        assert reconstructed.source_annotation_id == "ribosome_picks"
+
+    def test_particle_map_coordinate_reference_roundtrip(self):
+        """Particle maps should preserve links to source annotation references"""
+        original = ParticleMap(
+            path="/data/subtomograms/particle_001.mrc",
+            source_annotation_reference_id="average_ribosome_picks",
+            coord_index=3,
+            width=64,
+            height=64,
+            depth=64,
+        )
+
+        json_str = original.model_dump_json()
+        reconstructed = ParticleMap.model_validate_json(json_str)
+
+        assert reconstructed.source_annotation_reference_id == "average_ribosome_picks"
+        assert reconstructed.coord_index == 3
 
     def test_transformation_sequence_roundtrip(self):
         """Complex transformation sequences should survive round-trip"""
@@ -203,6 +252,7 @@ class TestConstraintValidation:
         """3D vectors must have exactly 3 elements"""
         with pytest.raises(ValidationError):
             PointSet3D(
+                id="bad_point_set",
                 annotation_type="point_set_3d",
                 origin3D=[[1.0, 2.0]],  # Missing z coordinate
             )
@@ -260,10 +310,15 @@ class TestConstraintValidation:
         """Point sets must have at least one point"""
         with pytest.raises(ValidationError):
             PointSet3D(
+                id="empty_point_set",
                 annotation_type="point_set_3D",
                 origin3D=[],  # Empty list not allowed
             )
 
         # Should work with one point
-        ps = PointSet3D(annotation_type="point_set_3D", origin3D=[[1.0, 2.0, 3.0]])
+        ps = PointSet3D(
+            id="single_point_set",
+            annotation_type="point_set_3D",
+            origin3D=[[1.0, 2.0, 3.0]],
+        )
         assert len(ps.origin3D) == 1

--- a/tests/test_data/expected_dataset.json
+++ b/tests/test_data/expected_dataset.json
@@ -327,8 +327,10 @@
       ],
       "annotations": [
         {
+          "id": "ribosome_picks",
           "annotation_type": "point_set_3D",
           "name": "ribosome_picks",
+          "source_tomogram_id": "tomogram_01",
           "origin3D": [
             [
               100.5,
@@ -383,6 +385,7 @@
           ]
         },
         {
+          "id": "oriented_particles",
           "annotation_type": "point_vector_set_3D",
           "name": "oriented_particles",
           "origin3D": [
@@ -413,6 +416,7 @@
           "coordinate_transformations": []
         },
         {
+          "id": "rotated_particles",
           "annotation_type": "point_matrix_set_3D",
           "name": "rotated_particles",
           "origin3D": [
@@ -445,6 +449,7 @@
           "coordinate_transformations": []
         },
         {
+          "id": "membrane_segmentation",
           "annotation_type": "segmentation_mask_3D",
           "name": "membrane_segmentation",
           "path": "/data/annotations/membrane_mask.mrc",
@@ -455,6 +460,7 @@
           "coordinate_transformations": []
         },
         {
+          "id": "ribosome_probability",
           "annotation_type": "probability_map_3D",
           "name": "ribosome_probability",
           "path": "/data/annotations/probability_map.mrc",
@@ -465,6 +471,7 @@
           "coordinate_transformations": []
         },
         {
+          "id": "fiducial_markers",
           "annotation_type": "point_set_2D",
           "name": "fiducial_markers",
           "origin2D": [
@@ -485,6 +492,7 @@
           "coordinate_transformations": []
         },
         {
+          "id": "membrane_surface",
           "annotation_type": "tri_mesh",
           "name": "membrane_surface",
           "coordinate_systems": [],
@@ -499,6 +507,8 @@
       "particle_maps": [
         {
           "path": "/data/averages/ribosome_map.mrc",
+          "source_annotation_reference_id": "average_ribosome_picks",
+          "coord_index": 0,
           "width": 256,
           "height": 256,
           "depth": 256,
@@ -561,17 +571,9 @@
       ],
       "annotations": [
         {
-          "annotation_type": "point_set_3D",
-          "name": "symmetry_points",
-          "origin3D": [
-            [
-              128.0,
-              128.0,
-              128.0
-            ]
-          ],
-          "coordinate_systems": [],
-          "coordinate_transformations": []
+          "id": "average_ribosome_picks",
+          "source_region_id": "region_01",
+          "source_annotation_id": "ribosome_picks"
         }
       ]
     }

--- a/tests/test_model_gen.py
+++ b/tests/test_model_gen.py
@@ -193,6 +193,7 @@ def test_type_alias_validation_works(models_path):
     PointSet3D = module.PointSet3D
 
     valid_points = PointSet3D(
+        id="test_points",
         annotation_type="point_set_3D",
         origin3D=[
             [1.0, 2.0, 3.0],
@@ -203,6 +204,7 @@ def test_type_alias_validation_works(models_path):
 
     with pytest.raises(ValidationError):
         PointSet3D(
+            id="bad_points_missing_z",
             annotation_type="point_set_3D",
             origin3D=[
                 [1.0, 2.0],  # Only 2 elements, should be 3
@@ -211,6 +213,7 @@ def test_type_alias_validation_works(models_path):
 
     with pytest.raises(ValidationError):
         PointSet3D(
+            id="bad_points_extra_coord",
             annotation_type="point_set_3D",
             origin3D=[
                 [1.0, 2.0, 3.0, 4.0],  # 4 elements, should be 3


### PR DESCRIPTION
Adds:

- tilt-series - Alignment relation via identifier fields.
- titl.image - ProjectionAlignment relation via identifier fields.

Comments:

1. This branch comes from the brunch containing the chosen solution (solution 2) https://github.com/TomoBabel/cets-data-models/tree/averages_region_linkage_solution_2, BUT merging it with branch main, as it is 3 commits behind.
2. It is expected to be merged into branch main once branch averages_region_linkage_solution_2 is merged into main.
3. Processed tilt-series from the Relion test dataset (until it is decided if it will be the one we finally use) https://www.ebi.ac.uk/empiar/EMPIAR-10164/ with both Scipion and IMOD have been tested successfully using the model generated from this branch scheme.

NOTE: the changes in models.py come from the merge with branch main