### PR TITLE
ci(schema,library): Add continuous integration.

### DIFF
--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -1,0 +1,52 @@
+name: codegen
+
+# Fails the build if the models generated from the LinkML schema no longer
+# match the committed src/cets_data_model/models/models.py -- i.e. someone
+# changed the schema or the generation config without regenerating models.py.
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+      - "LICENSE"
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+      - "LICENSE"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  models-up-to-date:
+    name: generated models match models.py
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install dev dependencies
+        run: |
+          pip install -e .[dev]
+          pip install 'linkml-runtime<1.10'
+
+      - name: Regenerate models from the LinkML schema
+        run: make gen-python
+
+      - name: Fail if generated models differ from committed models.py
+        run: |
+          output=$(make compare-models)
+          echo "$output"
+          if echo "$output" | grep -Eq 'Classes (added|removed|changed): [1-9]'; then
+            echo "::error::Regenerated models differ from committed src/cets_data_model/models/models.py. Run 'make gen-python' and sync models.py."
+            exit 1
+          fi

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -44,12 +44,5 @@ jobs:
           # release line; the rest feed the cets-data-model package line.
           scopes: |
             schema
-            models
-            codegen
-            utils
-            docs
-            deps
-            ci
-            tests
-            build
+            library
           requireScope: false

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,55 @@
+name: conventional-commits
+
+# Validates that the PR title is a Conventional Commit. On squash-merge the PR
+# title becomes the commit on main, which is what release-please parses to
+# decide the next version and changelog entry.
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pr-title:
+    name: validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Allowed commit types (prefixes) -- kept in sync with the
+          # changelog-sections in release-please-config.json.
+          types: |
+            feat
+            fix
+            perf
+            docs
+            refactor
+            revert
+            build
+            ci
+            test
+            chore
+            style
+          # Allowed scopes (components) -- project areas. Scope is optional, but
+          # when present must be one of these. schema/models feed the standard
+          # release line; the rest feed the cets-data-model package line.
+          scopes: |
+            schema
+            models
+            codegen
+            utils
+            docs
+            deps
+            ci
+            tests
+            build
+          requireScope: false

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,47 @@
+name: lint
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+      - "LICENSE"
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+      - "LICENSE"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: ruff + mypy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      # Installs the ruff / mypy versions pinned in pyproject.toml [dev]
+      # (ruff==0.11.12, mypy==1.8.0 -- kept in sync with .pre-commit-config.yaml).
+      - name: Install dev dependencies
+        run: pip install -e .[dev]
+
+      - name: Ruff (lint)
+        run: ruff check .
+
+      - name: Ruff (format)
+        run: ruff format --check .
+
+      # Typing is gated on the generated data models only. The utils package
+      # (image IO / numpy) has pre-existing type issues tracked separately.
+      - name: Mypy (models)
+        run: mypy src/cets_data_model/models

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,32 @@
+name: release-please
+
+# Maintains a running "release PR" that bumps the version (pyproject.toml) and
+# updates CHANGELOG.md from Conventional Commit messages on main. Merging that
+# PR tags the release and creates the GitHub Release.
+#
+# Note: no PyPI publish step is wired up here -- add one under a `needs:
+# release-please` job (with trusted publishing) if/when the package is released
+# to PyPI.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,49 @@
+name: tests
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+      - "LICENSE"
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+      - "LICENSE"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: py${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dev dependencies
+        run: |
+          pip install -e .[dev]
+          # linkml==1.9.6 leaves linkml-runtime unpinned; >=1.10 dropped
+          # Format.JSON and breaks gen-pydantic (exercised by the model-gen
+          # test). Keep the runtime on the compatible 1.9.x line.
+          pip install 'linkml-runtime<1.10'
+
+      # test_utils.py is a pre-existing broken module (imports a symbol that
+      # does not exist via a stale `src.`-prefixed path); tracked separately.
+      # Drop the --ignore once it is fixed.
+      - name: Run tests
+        run: pytest -q --ignore=tests/test_utils.py

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,5 @@
+{
+  ".": "0.1.0",
+  "schema": "0.0.1",
+  "src/cets_data_model/models": "0.0.1"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ namespaces = false
 
 [project]
 name = "cets_data_model"
-version = "0.1"
+version = "0.1.0"
 description = "Universal data standard for cryoET"
 license = {file = "LICENSE"}
 readme = "README.md"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,14 +3,14 @@
   "plugins": [
     {
       "type": "linked-versions",
-      "groupName": "cets-standard",
-      "components": ["schema", "models"]
+      "groupName": "schema",
+      "components": ["schema-linkml", "schema-models"]
     }
   ],
   "packages": {
     "schema": {
       "release-type": "simple",
-      "component": "schema",
+      "component": "schema-linkml",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
@@ -33,14 +33,14 @@
     },
     "src/cets_data_model/models": {
       "release-type": "simple",
-      "component": "models",
+      "component": "schema-models",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true
     },
     ".": {
       "release-type": "python",
-      "component": "cets-data-model",
+      "component": "library",
       "package-name": "cets_data_model",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "plugins": [
+    {
+      "type": "linked-versions",
+      "groupName": "cets-standard",
+      "components": ["schema", "models"]
+    }
+  ],
+  "packages": {
+    "schema": {
+      "release-type": "simple",
+      "component": "schema",
+      "changelog-path": "CHANGELOG.md",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "extra-files": [
+        { "type": "generic", "path": "linkml/entities.yaml" }
+      ],
+      "changelog-sections": [
+        { "type": "feat", "section": "Features" },
+        { "type": "fix", "section": "Bug Fixes" },
+        { "type": "docs", "section": "Documentation" },
+        { "type": "revert", "section": "Reverts" },
+        { "type": "refactor", "section": "Refactors", "hidden": true },
+        { "type": "perf", "section": "Performance Improvements", "hidden": true },
+        { "type": "ci", "section": "Continuous Integration", "hidden": true },
+        { "type": "test", "section": "Tests", "hidden": true },
+        { "type": "build", "section": "Build System", "hidden": true },
+        { "type": "style", "section": "Styles", "hidden": true },
+        { "type": "chore", "section": "Miscellaneous", "hidden": true }
+      ]
+    },
+    "src/cets_data_model/models": {
+      "release-type": "simple",
+      "component": "models",
+      "changelog-path": "CHANGELOG.md",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true
+    },
+    ".": {
+      "release-type": "python",
+      "component": "cets-data-model",
+      "package-name": "cets_data_model",
+      "changelog-path": "CHANGELOG.md",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "changelog-sections": [
+        { "type": "feat", "section": "Features" },
+        { "type": "fix", "section": "Bug Fixes" },
+        { "type": "perf", "section": "Performance Improvements" },
+        { "type": "docs", "section": "Documentation" },
+        { "type": "refactor", "section": "Refactors" },
+        { "type": "revert", "section": "Reverts" },
+        { "type": "build", "section": "Build System", "hidden": true },
+        { "type": "ci", "section": "Continuous Integration", "hidden": true },
+        { "type": "test", "section": "Tests", "hidden": true },
+        { "type": "style", "section": "Styles", "hidden": true },
+        { "type": "chore", "section": "Miscellaneous", "hidden": true }
+      ]
+    }
+  }
+}

--- a/schema/linkml/entities.yaml
+++ b/schema/linkml/entities.yaml
@@ -1,6 +1,6 @@
 name: CETMDEntities
 id: https://w3id.org/cetmd/entities
-version: 0.0.1
+version: 0.0.1 # x-release-please-version
 description: Schema for cryoET geometry
 
 prefixes:


### PR DESCRIPTION
This PR adds continuous integration for the project to improve quality of life.

### 1. Linting
`.github/workflows/lint.yml`

Runs ruff-linting and MyPy-type checking on every PR. 


### 2. Testing
`.github/workflows/test.yml`

Runs the tests on every PR

### 3. Codegen check
`.github/workflows/codegen.yml`

Runs codegen from the LinkML models and flags if the commited `models.py` differs from the version codegen'ed in CI. This prevents divergence of LinkML models and python library code. 

### 4. Release management with Release Please
`.github/workflows/release-please.yml`

The README states that schema versions are managed with semantic versioning. Until now this hasn't been enforced as it was under active development. It is good practice to have this in place and will make it easier to keep track of future changes and compatibilities with converters. For now we can keep this <1.0.0, but I think with changes coming it will be essential to have some versioning for our own sanity's sake. 

Versioning is automated using [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) syntax and [release-please](https://github.com/TomoBabel/cets-data-models/pull/28#issue-4906685355). The package is split into two components to keep versioning of the schema and surrounding package separate: 
- `schema`
- `library`

Versioning will be automatic via the PR titles and new releases will be cut using release PRs. 

Some example PR titles and their consequences: 

- "fix(schema): An editorial change." - This will increase the patch version of the `schema`-component. 
- "feat(schema): A new field introduced." - This will increase the minor version of the `schema`-component.
- "feat!(schema): A field was removed." - This will increase the major version of the `schema`-component.
- "feat(library): A change to codegen." - This will increase the minor version of the `library`-component. 
- "feat(library,schema): A change to codegen and fields." - This will increase the minor version of the `library` AND `schema`. 

All PRs will have to be merged as squash-PRs. Later, release to PyPI will be possible using this mechanism. The `.github/workflows/conventional-commits.yml`-action tests adherence to the PR-title conventions. 

Caveats: 
1. Some tests are ignored on purpose pending fix of #30 
2. MyPy is scoped to models pending fix of #29 